### PR TITLE
chore: use port 7001 instead of 5001 to avoid conflicts with forms

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,6 +38,7 @@ ports:
     port: 5432
     visibility: public
     onOpen: ignore
+    # OGCIO - formsie port collision fixed
   - port: 7001
     onOpen: ignore
   - port: 5002

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -38,7 +38,7 @@ ports:
     port: 5432
     visibility: public
     onOpen: ignore
-  - port: 5001
+  - port: 7001
     onOpen: ignore
   - port: 5002
     onOpen: ignore

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -11,7 +11,7 @@ import serveStatic from '#src/middleware/koa-serve-static.js';
 export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
   mountedApps: string[],
   packagePath = 'experience',
-  port = 5001,
+  port = 7001,
   prefix = ''
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {
   type Middleware = MiddlewareType<StateT, ContextT, ResponseBodyT>;

--- a/packages/core/src/middleware/koa-spa-proxy.ts
+++ b/packages/core/src/middleware/koa-spa-proxy.ts
@@ -11,6 +11,7 @@ import serveStatic from '#src/middleware/koa-serve-static.js';
 export default function koaSpaProxy<StateT, ContextT extends IRouterParamContext, ResponseBodyT>(
   mountedApps: string[],
   packagePath = 'experience',
+  // OGCIO - formsie port collision fixed
   port = 7001,
   prefix = ''
 ): MiddlewareType<StateT, ContextT, ResponseBodyT> {

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -72,7 +72,7 @@ const applicationRoutes = await pickDefault(import('./application.js'));
 const customClientMetadata = {
   corsAllowedOrigins: [
     'http://localhost:5000',
-    'http://localhost:5001',
+    'http://localhost:7001',
     'https://silverhand.com',
     'capacitor://localhost',
   ],

--- a/packages/core/src/routes/applications/application.test.ts
+++ b/packages/core/src/routes/applications/application.test.ts
@@ -72,6 +72,7 @@ const applicationRoutes = await pickDefault(import('./application.js'));
 const customClientMetadata = {
   corsAllowedOrigins: [
     'http://localhost:5000',
+    // OGCIO - formsie port collision fixed
     'http://localhost:7001',
     'https://silverhand.com',
     'capacitor://localhost',

--- a/packages/experience/package.json
+++ b/packages/experience/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "precommit": "lint-staged",
     "start": "parcel src/index.html",
-    "dev": "cross-env PORT=5001 parcel src/index.html --no-cache --hmr-port 6001",
+    "dev": "cross-env PORT=7001 parcel src/index.html --no-cache --hmr-port 6001",
     "check": "tsc --noEmit",
     "build": "pnpm check && rm -rf dist && parcel build src/index.html --no-autoinstall --no-cache --detailed-report",
     "lint": "eslint --ext .ts --ext .tsx src",


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)
### Ticket:

- [XXX](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/XXX)

### Description

Use the port `7001` instead of `5001` to avoid conflicts with forms when running both locally.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
