### PR TITLE
chore: add default public servant user to mygovid mock service and rename public servant

### DIFF
--- a/mygovid-mock-service/src/routes/static/mock-login.html
+++ b/mygovid-mock-service/src/routes/static/mock-login.html
@@ -213,7 +213,8 @@
       },
       {
         user_name: "Tony Stark",
-        govid_email: "tony.stark@mail.ie"
+        govid_email: "tony.stark@gov.ie",
+        is_public_servant: true
       },
     ]
   }

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -21,9 +21,9 @@
         },
         "organization_roles": [
             {
-                "id": "bb-public-servant",
-                "name": "Public Servant",
-                "description": "Building Blocks Public servant",
+                "id": "pay-public-servant",
+                "name": "Payments Public Servant",
+                "description": "Payments Public servant",
                 "specific_permissions": [
                     "payments:provider:*",
                     "payments:payment_request:*",

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
@@ -21,9 +21,9 @@
         },
         "organization_roles": [
             {
-                "id": "bb-public-servant",
-                "name": "Public Servant",
-                "description": "Building Blocks Public servant",
+                "id": "pay-public-servant",
+                "name": "Payments Public Servant",
+                "description": "Payments Public servant",
                 "specific_permissions": [
                     "payments:provider:*",
                     "payments:payment_request:*",

--- a/packages/core/src/libraries/ogcio-constants.ts
+++ b/packages/core/src/libraries/ogcio-constants.ts
@@ -3,7 +3,7 @@ export const OGCIO_ORGANIZATIONS = {
 };
 
 export const OGCIO_ORGANIZATION_ROLES = {
-  BB_PUBLIC_SERVANT: 'bb-public-servant',
+  BB_PUBLIC_SERVANT: 'pay-public-servant',
   MSG_PUBLIC_SERVANT: 'msg-public-servant',
 };
 


### PR DESCRIPTION
Add default public servant user to mygovid mock service.
Rename Public Servant for payments service to Payments Public Servant.