### PR TITLE
chore(core): added docker compose db file

### DIFF
--- a/README.OGCIO.md
+++ b/README.OGCIO.md
@@ -38,11 +38,11 @@ You can also run Logto natively on your machine outside the docker container.
 
 If you start Logto natively, the database won't be available, and you will have to start it separately. The database is still dockerized and has its own Docker Compose configuration. Use the following command to start the database container:
 
-`docker compose -f docker-compose-local.yml up -d postgres`
+`docker compose -f docker-compose-db.yml up -d`
 
 With the following command, you can shut down the database container:
 
-`docker compose -f docker-compose-local.yml down postgres`
+`docker compose -f docker-compose-db.yml down`
 
 ### Configuration and installation
 

--- a/docker-compose-db.yml
+++ b/docker-compose-db.yml
@@ -1,0 +1,22 @@
+# This file has been added on OGCIO fork
+services:
+  postgres:
+    image: postgres:14-alpine
+    user: postgres
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: p0stgr3s
+      PGPORT: 5433
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 5433:5433
+
+volumes:
+  db:
+    driver: local

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -24,21 +24,9 @@ services:
       - PORT=3301
       - ADMIN_PORT=3302
   postgres:
-    image: postgres:14-alpine
-    user: postgres
-    volumes:
-      - db:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: p0stgr3s
-      PGPORT: 5433
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    ports:
-      - 5433:5433
+    extends:
+      file: docker-compose-db.yaml
+      service: postgres
 
 volumes:
   db:

--- a/docker-compose-ogcio-logto.yml
+++ b/docker-compose-ogcio-logto.yml
@@ -29,9 +29,21 @@ services:
       - MOCK_KEYS_ENDPOINT=http://mygovid-mock-service:4005/logto/mock/keys
       
   postgres:
-    extends:
-      file: docker-compose-db.yaml
-      service: postgres
+    image: postgres:14-alpine
+    user: postgres
+    volumes:
+      - db:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: p0stgr3s
+      PGPORT: 5433
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    ports:
+      - 5433:5433
 
   mygovid-mock-service:
     image: mygovid-mock-service:latest

--- a/docker-compose-ogcio-logto.yml
+++ b/docker-compose-ogcio-logto.yml
@@ -29,21 +29,9 @@ services:
       - MOCK_KEYS_ENDPOINT=http://mygovid-mock-service:4005/logto/mock/keys
       
   postgres:
-    image: postgres:14-alpine
-    user: postgres
-    volumes:
-      - db:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: p0stgr3s
-      PGPORT: 5433
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-    ports:
-      - 5433:5433
+    extends:
+      file: docker-compose-db.yaml
+      service: postgres
 
   mygovid-mock-service:
     image: mygovid-mock-service:latest

--- a/makefile
+++ b/makefile
@@ -14,7 +14,7 @@ run-native:
 		cp -- ".env.sample" ".env"
 		@echo "${GREEN}Copied!${NC}"
 		@echo "${GREEN}Starting db...${NC}"
-		docker compose -f docker-compose-local.yml up --detach postgres
+		docker compose -f docker-compose-db.yml up --detach
 		@echo "${GREEN}Db started!${NC}"
 		@echo "${GREEN}Installing stuffs...${NC}"
 		pnpm pnpm:devPreinstall && pnpm i && pnpm prepack

--- a/mygovid-mock-service/src/routes/static/mock-login.html
+++ b/mygovid-mock-service/src/routes/static/mock-login.html
@@ -196,6 +196,7 @@
 
 <script type="module">
   import { faker } from "https://esm.sh/@faker-js/faker";
+
   let isCurrentUserSet = false;
   const returnUrl = new URLSearchParams(window.location.search).get(
     "return_url",
@@ -227,6 +228,8 @@
 
   const usersSelectElement = document.querySelector("#user_select");
   
+  const getRandomString = (size = 20) => [...Array(size)].map(() => Math.floor(Math.random() * 16).toString(16)).join('');
+
   for (const u of apiUsers.users) {
     var option = document.createElement("option");
     option.text = `${u.user_name} ${
@@ -256,8 +259,8 @@
       lastName = faker.person.lastName();
       email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@mail.ie`;
       isCurrentUserSet = false;
-      oid = crypto.randomBytes(20).toString("hex");
-      sub = crypto.randomBytes(20).toString("hex");
+      oid = getRandomString();
+      sub = getRandomString();
     }
 
     document.querySelector("#firstName").value = firstName;
@@ -276,6 +279,8 @@
   document.querySelector("#firstName").value = firstName;
   document.querySelector("#lastName").value = lastName;
   document.querySelector("#email").value = email;
+  document.querySelector("#oid").value = getRandomString();
+  document.querySelector("#sub").value = getRandomString();
 
   document.querySelector("#submit_btn").innerHTML =
     `<div style="margin-top: 5px">Login ${firstName} ${lastName} <span class="icon-signin_id_logo"></span></div>`;


### PR DESCRIPTION

### Description

I've readded a docker compose file that only contains the db service.

_Why?_ Because, using the `docker compose -f docker-compose-local.yml up -d postgres` approach you must already have the logto image built on your machine but the purpose of `make run-native` is to avoid building that.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [] **New feature**
- [x] **Dev change**