### PR TITLE
[19838] Add mock service to docker compose local file

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -25,6 +25,13 @@ services:
       - ADMIN_PORT=3302
       - MOCK_TOKEN_ENDPOINT=http://mygovid-mock-service:4005/logto/mock/token
       - MOCK_KEYS_ENDPOINT=http://mygovid-mock-service:4005/logto/mock/keys
+  
+  mygovid-mock-service:
+    image: local-mygovid-mock-service:latest
+    build:
+      dockerfile: ./mygovid-mock-service/Dockerfile
+    ports:
+      - 4005:4005
       
   postgres:
     extends:

--- a/makefile
+++ b/makefile
@@ -1,10 +1,12 @@
 # This file has been added on OGCIO fork
 TAG = local-logto:latest
+MOCK_SERVICE_TAG = local-mygovid-mock-service:latest
 GREEN=\033[0;32m
 NC=\033[0m
 
 build:
 		docker build -t ${TAG} .
+		docker build -f ./mygovid-mock-service/Dockerfile -t ${MOCK_SERVICE_TAG} .
 run:
 		docker-compose -f docker-compose-local.yml up --detach
 down:


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)
### Ticket:

- [19838](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/19838)

### Description

Add MyGovId mock service to docker-compose-local.yml so the mock service container is spun up too.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
