### PR TITLE
fix: dockerignore - exclude node_modules in subfolders

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 # dependencies
-node_modules
+**/node_modules
 
 # testing
 /packages/**/coverage

--- a/mygovid-mock-service/.dockerignore
+++ b/mygovid-mock-service/.dockerignore
@@ -1,2 +1,2 @@
-node_modules
+**/node_modules
 dist


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)

### Description

When building with docker, the node_modules folder in any of the subfolders would be copied over with the COPY command.
This could trigger issues with dependencies and compatibility by replacing the node_modules folder that was created using npm i inside the docker image, and also would make the process a bit slower.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
