### PR TITLE
feat(cli): add support for seeding always_issue_refresh_token option

### DIFF
--- a/packages/cli/src/commands/database/ogcio/applications.ts
+++ b/packages/cli/src/commands/database/ogcio/applications.ts
@@ -65,9 +65,12 @@ const fillApplications = (
       secret: inputApp.secret,
       description: inputApp.description,
       type: inputApp.type,
-      oidc_client_metadata: `{"redirectUris": ${createArrayString(inputApp.redirect_uri)}, "postLogoutRedirectUris": ${createArrayString(inputApp.logout_redirect_uri)}}`,
-      custom_client_metadata:
-        '{"idTokenTtl": 3600, "corsAllowedOrigins": [], "rotateRefreshToken": true, "refreshTokenTtlInDays": 14, "alwaysIssueRefreshToken": false}',
+      oidc_client_metadata: `{"redirectUris": ${createArrayString(
+        inputApp.redirect_uri
+      )}, "postLogoutRedirectUris": ${createArrayString(inputApp.logout_redirect_uri)}}`,
+      custom_client_metadata: `{"idTokenTtl": 3600, "corsAllowedOrigins": [], "rotateRefreshToken": true, "refreshTokenTtlInDays": 14, "alwaysIssueRefreshToken": ${
+        inputApp.always_issue_refresh_token ?? false
+      }}`,
       is_third_party: inputApp.is_third_party ?? false,
     };
   }

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -169,7 +169,8 @@
         "logout_redirect_uri": "http://localhost:8055",
         "secret": "analytics_app_local_secret",
         "id": "kgz1zomlw27cxx4pxh5gi",
-        "is_third_party": false
+        "is_third_party": false,
+        "always_issue_refresh_token": true
       },
       {
         "name": "Home Building Block",

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder.ts
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder.ts
@@ -46,6 +46,7 @@ export type ApplicationSeeder = {
   logout_redirect_uri: string | string[];
   secret: string;
   is_third_party?: boolean;
+  always_issue_refresh_token?: boolean;
 };
 
 export type ResourceSeeder = {


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)
### Ticket:

- [20279](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/20279)

### Description

When integrating with Matomo, it is required that the refresh token is always part of the /token response, to ensure that we can get the details for the user's organizations.
This PR exposes the option in the seeder

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
