### PR TITLE
Fix(OGCIO): fix m2m permissions

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -260,7 +260,8 @@
           "profile:address.self:read",
           "profile:address.self:write",
           "profile:entitlement.self:read",
-          "profile:entitlement.self:write"
+          "profile:entitlement.self:write",
+          "profile:user:read"
         ]
       },
       {
@@ -324,7 +325,7 @@
           {
             "resource_id": "profile-api",
             "specific_permissions": [
-              "profile:user.self:read"
+              "profile:user:read"
             ]
           }
         ],

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
@@ -225,7 +225,8 @@
           "profile:address.self:read",
           "profile:address.self:write",
           "profile:entitlement.self:read",
-          "profile:entitlement.self:write"
+          "profile:entitlement.self:write",
+          "profile:user:read"
         ]
       },
       {
@@ -289,7 +290,7 @@
           {
             "resource_id": "profile-api",
             "specific_permissions": [
-              "profile:user.self:read"
+              "profile:user:read"
             ]
           }
         ],


### PR DESCRIPTION
### Description

Until we will manage the impersonation we decided to assign the `profile:user:read` permission to the M2M application so to be able to read the data of the logged in user.

Why not use the `profile:user.self:read` permissions? Because when logging in as M2M application the user id in the token would be another one than the id of the user logged in in the UI application, then the self permissions won't be enough

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [] **Dev change**
