### PR TITLE
Feature(OGCIO): add testing organisations

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -10,6 +10,16 @@
         "name": "Inactive Public Servants Org",
         "description": "Temporary organization for inactive Public Servants",
         "id": "inactive-ps-org"
+      },
+      {
+        "name": "First Testing Organisation",
+        "description": "Organisation used to do E2E testing",
+        "id": "first-testing"
+      },
+      {
+        "name": "Second Testing Organisation",
+        "description": "Organisation used to do E2E testing",
+        "id": "second-testing"
       }
     ],
     "organization_permissions": {
@@ -118,6 +128,23 @@
         ],
         "type": "MachineToMachine",
         "related_applications": [{"application_id":"ddl4llp30risjwcjymqw3", "organization_id": "ogcio"}]
+      },
+      {
+        "id": "m2m-e2e-tester",
+        "name": "M2M E2E Tester Role",
+        "description": "Role for M2M Applications that need to perform E2E testing",
+        "specific_permissions": [
+          "messaging:message:*",
+          "messaging:provider:*",
+          "messaging:template:*",
+          "messaging:citizen:*",
+          "messaging:event:read"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          {"application_id":"qrtllp45fgbvsdjyasd5", "organization_id": "first-testing"},
+          {"application_id":"qrtllp45fgbvsdjyasd5", "organization_id": "second-testing"}
+        ]
       }
     ],
     "applications": [
@@ -200,6 +227,16 @@
         "logout_redirect_uri": "",
         "secret": "profile_reader_local_secret",
         "id": "ddl4llp30risjwcjymqw3",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M E2E Tester",
+        "description": "Machine 2 Machine application used to do E2E testing",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "e2e_tester_local_secret",
+        "id": "qrtllp45fgbvsdjyasd5",
         "is_third_party": false
       }
     ],

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-testing.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-testing.json
@@ -1,0 +1,424 @@
+{
+  "default": {
+    "organizations": [
+      {
+        "name": "OGCIO",
+        "description": "OGCIO Organization",
+        "id": "ogcio"
+      },
+      {
+        "name": "Inactive Public Servants Org",
+        "description": "Temporary organization for inactive Public Servants",
+        "id": "inactive-ps-org"
+      },
+      {
+        "name": "First Testing Organisation",
+        "description": "Organisation used to do E2E testing",
+        "id": "first-testing"
+      },
+      {
+        "name": "Second Testing Organisation",
+        "description": "Organisation used to do E2E testing",
+        "id": "second-testing"
+      }
+    ],
+    "organization_permissions": {
+      "specific_permissions": [
+        "payments:provider:*",
+        "payments:payment_request:*",
+        "payments:payment_request.public:read",
+        "payments:transaction:*",
+        "messaging:message:*",
+        "messaging:provider:*",
+        "messaging:template:*",
+        "messaging:citizen:*",
+        "messaging:event:read",
+        "profile:user:read",
+        "profile:user:*",
+        "profile:address:*",
+        "profile:entitlement:*",
+        "life-events:digital-wallet-flow:*",
+        "bb:public-servant.inactive:*",
+        "scheduler:jobs:write",
+        "upload:file:*"
+      ]
+    },
+    "organization_roles": [
+      {
+        "id": "pay-public-servant",
+        "name": "Payments Public Servant",
+        "description": "Payments Public servant",
+        "specific_permissions": [
+          "payments:provider:*",
+          "payments:payment_request:*",
+          "payments:payment_request.public:read",
+          "payments:transaction:*",
+          "scheduler:jobs:write"
+        ]
+      },
+      {
+        "id": "msg-public-servant",
+        "name": "Messaging Public Servant",
+        "description": "Messaging Public servant",
+        "specific_permissions": [
+          "messaging:message:*",
+          "messaging:provider:*",
+          "messaging:template:*",
+          "messaging:citizen:*",
+          "messaging:event:read",
+          "scheduler:jobs:write"
+        ]
+      },
+      {
+        "id": "le-public-servant",
+        "name": "Life Events Public Servant",
+        "description": "Life Events Public servant",
+        "specific_permissions": ["life-events:digital-wallet-flow:*"]
+      },
+      {
+        "id": "pro-public-servant",
+        "name": "Profile Public Servant",
+        "description": "Profile Public servant",
+        "specific_permissions": ["profile:user:*", "profile:address:*", "profile:entitlement:*"]
+      },
+      {
+        "id": "upload-public-servant",
+        "name": "File Upload Public Servant",
+        "description": "File Upload Public servant",
+        "specific_permissions": ["upload:file:*"]
+      },
+      {
+        "id": "bb-inactive-ps",
+        "name": "Inactive Public Servant",
+        "description": "Inactive Public Servant",
+        "specific_permissions": [
+          "bb:public-servant.inactive:*"
+        ]
+      },
+      {
+        "id": "m2m-ps-profile-reader",
+        "name": "M2M Public Servant Profile Reader",
+        "description": "Role for M2M Applications that need to read from Profile resources",
+        "specific_permissions": [
+          "profile:user:read"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [{"application_id":"tty6llp30risjwcjhbvc9", "organization_id": "ogcio"}]
+      },
+      {
+        "id": "m2m-e2e-tester",
+        "name": "M2M E2E Tester Role",
+        "description": "Role for M2M Applications that need to perform E2E testing",
+        "specific_permissions": [
+          "messaging:message:*",
+          "messaging:provider:*",
+          "messaging:template:*",
+          "messaging:citizen:*",
+          "messaging:event:read"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          {"application_id":"treftr21fgbvsdjwlol9", "organization_id": "first-testing"},
+          {"application_id":"treftr21fgbvsdjwlol9", "organization_id": "second-testing"}
+        ]
+      }
+    ],
+    "applications": [
+      {
+        "name": "Payments Building Block",
+        "description": "Payments App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_PAYMENTS_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_PAYMENTS_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_PAYMENTS_APP_SECRET>",
+        "id": "r5f56tpkytpqyyshiutd2",
+        "is_third_party": false
+      },
+      {
+        "name": "Messaging Building Block",
+        "description": "Messaging App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_MESSAGING_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_MESSAGING_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_MESSAGING_APP_SECRET>",
+        "id": "1lvmteh2ao3xrswyq7j3e",
+        "is_third_party": false
+      },
+      {
+        "name": "Life Events",
+        "description": "Life Events App",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_LIFE_EVENTS_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_LIFE_EVENTS_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_LIFE_EVENTS_APP_SECRET>",
+        "id": "i61nya0wctzpqeyeno54z",
+        "is_third_party": false
+      },
+      {
+        "name": "Home Building Block",
+        "description": "Building Blocks home application",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_HOME_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_HOME_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_HOME_APP_SECRET>",
+        "id": "4icd76x8we31j1e8bqyfn",
+        "is_third_party": false
+      },
+      {
+        "name": "File Upload Service",
+        "description": "File Upload Service",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_UPLOAD_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_UPLOAD_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_UPLOAD_APP_SECRET>",
+        "id": "8mdj23ty5vk94w7rblxhf",
+        "is_third_party": false
+      },
+      {
+        "name": "Profile Building Block",
+        "description": "Profile App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_PROFILE_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_PROFILE_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_PROFILE_APP_SECRET>",
+        "id": "0921d8onfb9f3bv75trgf",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Profile Reader",
+        "description": "Machine 2 Machine application used to communicate between services and Profile resource",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_PROFILE_APP_SECRET>",
+        "id": "tty6llp30risjwcjhbvc9",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M E2E Tester",
+        "description": "Machine 2 Machine application used to do E2E testing",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_E2E_TESTER_APP_SECRET>",
+        "id": "treftr21fgbvsdjwlol9",
+        "is_third_party": false
+      }
+    ],
+    "resources": [
+      {
+        "id": "payments-api",
+        "name": "Payments Building Block API",
+        "indicator": "<SEEDER_PAYMENTS_API_INDICATOR>"
+      },
+      {
+        "id": "messaging-api",
+        "name": "Messaging Building Block API",
+        "indicator": "<SEEDER_MESSAGING_API_INDICATOR>"
+      },
+      {
+        "id": "scheduler-api",
+        "name": "Scheduler Building Block API",
+        "indicator": "<SEEDER_SCHEDULER_API_INDICATOR>"
+      },
+      {
+        "id": "profile-api",
+        "name": "Profile Building Block API",
+        "indicator": "<SEEDER_PROFILE_API_INDICATOR>"
+      },
+      {
+        "id": "upload-api",
+        "name": "Upload Building Block API",
+        "indicator": "<SEEDER_UPLOAD_API_INDICATOR>"
+      }
+    ],
+    "resource_permissions": [
+      {
+        "resource_id": "payments-api",
+        "specific_permissions": [
+          "payments:transaction.self:read",
+          "payments:payment_request.public:read",
+          "payments:transaction.self:write",
+          "payments:provider.public:read"
+        ]
+      },
+      {
+        "resource_id": "messaging-api",
+        "specific_permissions": [
+          "messaging:message.self:read",
+          "messaging:citizen.self:read",
+          "messaging:citizen.self:write"
+        ]
+      },
+      {
+        "resource_id": "scheduler-api",
+        "specific_permissions": ["scheduler:jobs:write"]
+      },
+      {
+        "resource_id": "profile-api",
+        "specific_permissions": [
+          "profile:user.self:read",
+          "profile:user.self:write",
+          "profile:address.self:read",
+          "profile:address.self:write",
+          "profile:entitlement.self:read",
+          "profile:entitlement.self:write",
+          "profile:user:read"
+        ]
+      },
+      {
+        "resource_id": "upload-api",
+        "specific_permissions": [
+          "upload:file.self:write",
+          "upload:file.self:read",
+          "upload:file.self:delete"
+        ]
+      }
+    ],
+    "resource_roles": [
+      {
+        "id": "bb-citizen",
+        "name": "Citizen",
+        "description": "A citizen using Life Events and the Building Blocks ecosystem",
+        "permissions": [
+          {
+            "resource_id": "payments-api",
+            "specific_permissions": [
+              "payments:transaction.self:read",
+              "payments:payment_request.public:read",
+              "payments:transaction.self:write",
+              "payments:provider.public:read"
+            ]
+          },
+          {
+            "resource_id": "messaging-api",
+            "specific_permissions": [
+              "messaging:message.self:read",
+              "messaging:citizen.self:read",
+              "messaging:citizen.self:write"
+            ]
+          },
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": [
+              "profile:user.self:read",
+              "profile:user.self:write",
+              "profile:address.self:read",
+              "profile:address.self:write",
+              "profile:entitlement.self:read",
+              "profile:entitlement.self:write"
+            ]
+          },
+          {
+            "resource_id": "upload-api",
+            "specific_permissions": [
+              "upload:file.self:write",
+              "upload:file.self:read",
+              "upload:file.self:delete"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "m2m-citizen-profile",
+        "name": "M2M Citizen Profile Reader role",
+        "description": "Role used to make M2M applications able to read from profile resource",
+        "permissions": [
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": [
+              "profile:user:read"
+            ]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["tty6llp30risjwcjhbvc9"]
+      }
+    ],
+    "connectors": [
+      {
+        "id": "mygovid",
+        "sync_profile": true,
+        "connector_id": "mygovid",
+        "config": {
+          "scope": "openid profile email",
+          "clientId": "<SEEDER_MYGOVID_CONNECTOR_CLIENT_ID>",
+          "clientSecret": "<SEEDER_MYGOVID_CONNECTOR_CLIENT_SECRET>",
+          "tokenEndpoint": "<SEEDER_MYGOVID_CONNECTOR_TOKEN_ENDPOINT>",
+          "authorizationEndpoint": "<SEEDER_MYGOVID_CONNECTOR_AUTHORIZATION_ENDPOINT>",
+          "tokenEndpointAuthMethod": "client_secret_post",
+          "idTokenVerificationConfig": {
+            "jwksUri": "<SEEDER_MYGOVID_CONNECTOR_JWS_URI>"
+          },
+          "clientSecretJwtSigningAlgorithm": "HS256"
+        },
+        "metadata": {
+          "logo": "https://mygovidstatic.blob.core.windows.net/assets/images/favicon_196x196.png",
+          "name": {
+            "en": "MyGovId"
+          },
+          "target": "MyGovId (MyGovId connector)"
+        }
+      },
+      {
+        "id": "ogcio-entraid",
+        "sync_profile": true,
+        "connector_id": "ogcio-entraid",
+        "config": {
+          "clientId": "<SEEDER_ENTRAID_CONNECTOR_CLIENT_ID>",
+          "tenantId": "organizations",
+          "clientSecret": "<SEEDER_ENTRAID_CONNECTOR_CLIENT_SECRET>",
+          "cloudInstance": "https://login.microsoftonline.com"
+        },
+        "metadata": {
+          "target": "OGCIO EntraID"
+        }
+      }
+    ],
+    "sign_in_experiences": [
+      {
+        "id": "default",
+        "color": {
+          "primaryColor": "#007DA6",
+          "darkPrimaryColor": "#007DA6",
+          "isDarkModeEnabled": false
+        },
+        "branding": {
+          "logoUrl": "https://mygovidstatic.blob.core.windows.net/assets/images/helpchat-logo.png",
+          "darkLogoUrl": "https://mygovidstatic.blob.core.windows.net/assets/images/helpchat-logo.png"
+        },
+        "language_info": {
+          "autoDetect": true,
+          "fallbackLanguage": "en"
+        },
+        "sign_in": {
+          "methods": []
+        },
+        "sign_up": {
+          "verify": false,
+          "password": false,
+          "identifiers": []
+        },
+        "social_sign_in_connector_targets": ["MyGovId (MyGovId connector)", "OGCIO EntraID"],
+        "sign_in_mode": "SignInAndRegister"
+      }
+    ],
+    "webhooks": [
+      {
+        "id": "login-webhook",
+        "name": "User log in",
+        "events": [
+          "User.Created",
+          "User.Deleted",
+          "User.Data.Updated",
+          "User.SuspensionStatus.Updated"
+        ],
+        "config": {
+          "url": "<SEEDER_WEBHOOK_LOGIN_URL>"
+        },
+        "signing_key": "<SEEDER_WEBHOOK_SIGNING_KEY>",
+        "enabled": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Description

As discussed, I've added a new seeding file to be deployed in dev and sta (linked Terraform PR [here](https://github.com/ogcio/life-events-terraform/pull/108)) and the new E2E testing organisations, app and role

At the moment we decided to just add the "public servant" role because until we have impersonation would not be possible to test the *self* permissions as M2M application

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**
