### PR TITLE
feat(cli): change analytics permissions name

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -25,9 +25,9 @@
     "organization_permissions": {
       "specific_permissions": [
         "analytics:global:*",
-        "analytics:website:admin",
-        "analytics:website:write",
-        "analytics:website:view",
+        "analytics:measurable:admin",
+        "analytics:measurable:write",
+        "analytics:measurable:view",
         "payments:provider:*",
         "payments:payment_request:*",
         "payments:payment_request.public:read",
@@ -89,13 +89,13 @@
         "id": "anl-admin",
         "name": "Analytics Admin",
         "description": "Analytics Admin",
-        "specific_permissions": ["analytics:website:admin"]
+        "specific_permissions": ["analytics:measurable:admin"]
       },
       {
         "id": "anl-public-servant",
         "name": "Analytics Public Servant",
         "description": "Analytics Public servant",
-        "specific_permissions": ["analytics:website:view"]
+        "specific_permissions": ["analytics:measurable:view"]
       },
       {
         "id": "anl-super-user",

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
@@ -15,9 +15,9 @@
     "organization_permissions": {
       "specific_permissions": [
         "analytics:global:*",
-        "analytics:website:admin",
-        "analytics:website:write",
-        "analytics:website:view",
+        "analytics:measurable:admin",
+        "analytics:measurable:write",
+        "analytics:measurable:view",
         "payments:provider:*",
         "payments:payment_request:*",
         "payments:payment_request.public:read",
@@ -79,13 +79,13 @@
         "id": "anl-admin",
         "name": "Analytics Admin",
         "description": "Analytics Admin",
-        "specific_permissions": ["analytics:website:admin"]
+        "specific_permissions": ["analytics:measurable:admin"]
       },
       {
         "id": "anl-public-servant",
         "name": "Analytics Public Servant",
         "description": "Analytics Public servant",
-        "specific_permissions": ["analytics:website:view"]
+        "specific_permissions": ["analytics:measurable:view"]
       },
       {
         "id": "anl-super-user",
@@ -124,7 +124,7 @@
         "related_applications": [
           { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "ogcio" }
         ]
-      }      
+      }
     ],
     "applications": [
       {


### PR DESCRIPTION
### Ticket:

- [21366](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/21366)

### Description

Rename the Matomo permission `website` to `measurable` to avoid naming-conflict with the upcoming `analytics:website` permission, which will refer to the Analytics API feature.


## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
