### PR TITLE
Spike: Show connector based on cookie value

### DIFF
--- a/packages/experience/src/pages/SignIn/index.tsx
+++ b/packages/experience/src/pages/SignIn/index.tsx
@@ -95,6 +95,30 @@ const SignIn = () => {
   const { signInMethods, socialConnectors, signInMode } = useSieMethods();
   const { agreeToTermsPolicy } = useTerms();
 
+  // OGIO - to define where to put this code (UI layer or enywhere else)
+  const getCookieValue = (cookieName: string) => {
+    const cookies = document.cookie.split("; ");
+    for (const cookie of cookies) {
+      const [name, value] = cookie.split("=");
+      if(!value) return 
+      if (name === cookieName) {
+        return decodeURIComponent(value);
+      }
+    }
+    return null;
+  };
+  
+  const connectorsToShowCookie = getCookieValue("connectorsToShow");
+
+  let filteredSocialConnectors = [];
+  if (connectorsToShowCookie) {
+    const connectorsToShow = connectorsToShowCookie.split(",");
+    filteredSocialConnectors = socialConnectors.filter(connector => connectorsToShow.includes(connector.id));
+  } else {
+    filteredSocialConnectors = socialConnectors;
+  }
+ 
+
   if (!signInMode) {
     return <ErrorPage />;
   }
@@ -107,7 +131,7 @@ const SignIn = () => {
     <LandingPageLayout title="description.sign_in_to_your_account">
       <GoogleOneTap context="signin" />
       <SingleSignOnFormModeContextProvider>
-        <Main signInMethods={signInMethods} socialConnectors={socialConnectors} />
+        <Main signInMethods={signInMethods} socialConnectors={filteredSocialConnectors} />
         <SignInFooters />
       </SingleSignOnFormModeContextProvider>
       {


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)
### Ticket:

- [25836](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/25836)

### Description

This is a test - we want to validate if on Dev we're able to read the cookies set from the Payments application to allow the Logto ui to show/hide specific connectors. This is not a definitive solution, but is part of a spike

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [X] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
