### PR TITLE
Chore: AB#27483 add test permissions uat

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": "^20.9.0",
-    "pnpm": "^9.0.0"
+    "pnpm": "^10.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "engines": {
     "node": "^20.9.0",
-    "pnpm": "^10.0.0"
+    "pnpm": "^9.0.0"
   },
   "pnpm": {
     "overrides": {

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
@@ -1,0 +1,1137 @@
+{
+  "default": {
+    "organizations": [
+      {
+        "name": "OGCIO",
+        "description": "OGCIO Organization",
+        "id": "ogcio"
+      },
+      {
+        "name": "Nearform Testing Org",
+        "description": "Testing organization created through seeder",
+        "id": "nearform-testing"
+      },
+      {
+        "name": "An Bord Pleanála",
+        "description": "An Bord Pleanála",
+        "id": "abp"
+      },
+      {
+        "name": "Inactive Public Servants Org",
+        "description": "Temporary organization for inactive Public Servants",
+        "id": "inactive-ps-org"
+      },
+      {
+        "name": "Dept. of Education/An Roinn Oideachais",
+        "description": "Dept. of Education/An Roinn Oideachais - Imported from Digital Postbox",
+        "id": "doe"
+      },
+      {
+        "name": "Health Service Executive",
+        "description": "Health Service Executive - Imported from Digital Postbox",
+        "id": "hse"
+      },
+      {
+        "name": "Department of Social Protection",
+        "description": "Department of Social Protection - Imported from Digital Postbox",
+        "id": "dsp"
+      },
+      {
+        "name": "Limerick City and County Council",
+        "description": "Limerick City and County Council - Imported from Digital Postbox",
+        "id": "lcc"
+      },
+      {
+        "name": "Messaging Test",
+        "description": "Messaging Test - Imported from Digital Postbox",
+        "id": "msg-dp"
+      }
+    ],
+    "organization_permissions": {
+      "specific_permissions": [
+        "analytics:global:*",
+        "analytics:measurable:admin",
+        "analytics:measurable:write",
+        "analytics:measurable:view",
+        "analytics:website:read",
+        "analytics:website:write",
+        "analytics:website:tracking",
+        "analytics:audit_log:read",
+        "payments:provider:read",
+        "payments:provider:*",
+        "payments:payment_request:read",
+        "payments:payment_request:*",
+        "payments:payment_request.public:read",
+        "payments:transaction:read",
+        "payments:transaction:*",
+        "payments:auditLog:read",
+        "messaging:message:*",
+        "messaging:provider:*",
+        "messaging:template:*",
+        "messaging:event:read",
+        "o11y:dashboard:read",
+        "o11y:dashboard:write",
+        "o11y:dashboard:admin",
+        "profile:user:read",
+        "profile:user:write",
+        "profile:user:*",
+        "profile:user.self:read",
+        "profile:user.self:write",
+        "profile:user.admin:*",
+        "life-events:digital-wallet-flow:*",
+        "bb:public-servant.inactive:*",
+        "scheduler:jobs:write",
+        "upload:file:*",
+        "o11y:metrics:*",
+        "journey:journey.public:read",
+        "journey:journey:read",
+        "journey:journey:*",
+        "journey:step:*",
+        "journey:run:*",
+        "journey:run:read",
+        "journey:run:write",
+        "dashboard:admin:read",
+        "dashboard:admin:write",
+        "formsie:submission:read",
+        "profile:user.admin:write",
+        "profile:user.admin:read"
+      ]
+    },
+    "organization_roles": [
+      {
+        "id": "pay-public-servant",
+        "name": "Payments Public Servant",
+        "description": "Payments Public servant",
+        "specific_permissions": [
+          "payments:provider:*",
+          "payments:payment_request:*",
+          "payments:payment_request.public:read",
+          "payments:transaction:*",
+          "scheduler:jobs:write",
+          "profile:user.self:read",
+          "profile:user.self:write",
+          "payments:auditLog:read"
+        ]
+      },
+      {
+        "id": "pay-read-only",
+        "name": "Payments Read-Only",
+        "description": "Payments Read-Only",
+        "specific_permissions": [
+          "payments:provider:read",
+          "payments:payment_request:read",
+          "payments:payment_request.public:read",
+          "payments:transaction:read",
+          "profile:user.self:read",
+          "payments:auditLog:read"
+        ]
+      },
+      {
+        "id": "msg-public-servant",
+        "name": "Messaging Public Servant",
+        "description": "Messaging Public servant",
+        "specific_permissions": [
+          "messaging:message:*",
+          "messaging:provider:*",
+          "messaging:template:*",
+          "messaging:event:read",
+          "scheduler:jobs:write",
+          "profile:user:read",
+          "profile:user.self:read",
+          "profile:user.self:write"
+        ]
+      },
+      {
+        "id": "db-public-servant",
+        "name": "Dashboard Public Servant",
+        "description": "Dashboard Public servant",
+        "specific_permissions": [
+          "dashboard:admin:read",
+          "dashboard:admin:write",
+          "profile:user.self:read",
+          "profile:user.self:write"
+        ]
+      },
+      {
+        "id": "le-public-servant",
+        "name": "Life Events Public Servant",
+        "description": "Life Events Public servant",
+        "specific_permissions": [
+          "life-events:digital-wallet-flow:*",
+          "profile:user.self:read",
+          "profile:user.self:write"
+        ]
+      },
+      {
+        "id": "pro-public-servant",
+        "name": "Profile Public Servant",
+        "description": "Profile Public servant",
+        "specific_permissions": ["profile:user:*"]
+      },
+      {
+        "id": "anl-admin",
+        "name": "Analytics Admin",
+        "description": "Analytics Admin",
+        "specific_permissions": ["analytics:measurable:admin"]
+      },
+      {
+        "id": "anl-public-servant",
+        "name": "Analytics Public Servant",
+        "description": "Analytics Public servant",
+        "specific_permissions": ["analytics:measurable:view"]
+      },
+      {
+        "id": "anl-super-user",
+        "name": "Analytics Super User",
+        "description": "Analytics Super User",
+        "specific_permissions": ["analytics:global:*"]
+      },
+      {
+        "id": "upload-public-servant",
+        "name": "File Upload Public Servant",
+        "description": "File Upload Public servant",
+        "specific_permissions": [
+          "upload:file:*",
+          "profile:user:read",
+          "profile:user.self:read",
+          "profile:user.self:write"
+        ]
+      },
+      {
+        "id": "int-public-servant",
+        "name": "Journey Public Servant",
+        "description": "Journey Public servant",
+        "specific_permissions": [
+          "journey:journey:*",
+          "journey:step:*",
+          "journey:run:read",
+          "journey:run:write",
+          "profile:user.self:read",
+          "profile:user.self:write"
+        ]
+      },
+      {
+        "id": "bb-inactive-ps",
+        "name": "Inactive Public Servant",
+        "description": "Inactive Public Servant",
+        "specific_permissions": ["bb:public-servant.inactive:*"]
+      },
+      {
+        "id": "m2m-ps-profile-reader",
+        "name": "M2M Public Servant Profile Reader",
+        "description": "Role for M2M Applications that need to read from Profile resources",
+        "specific_permissions": ["profile:user:read"],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "tty6llp30risjwcjhbvc9", "organization_id": "ogcio" },
+          { "application_id": "tty6llp30risjwcjhbvc9", "organization_id": "abp" },
+          { "application_id": "okzj8uam29yhj4zdj21xm", "organization_id": "ogcio" },
+          { "application_id": "okzj8uam29yhj4zdj21xm", "organization_id": "abp" },
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "lcc"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "msg-dp"}
+        ]
+      },
+      {
+        "id": "m2m-ps-profile-writer",
+        "name": "M2M Public Servant Profile Writer",
+        "description": "Role for M2M Applications that need to write Profile resources",
+        "specific_permissions": [
+          "profile:user:write"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "okzj8uam29yhj4zdj21xm", "organization_id": "ogcio" },
+          { "application_id": "okzj8uam29yhj4zdj21xm", "organization_id": "abp" },
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "lcc"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "msg-dp"}
+        ]
+      },
+      {
+        "id": "m2m-ps-profile-admin",
+        "name": "M2M Public Servant Profile Admin",
+        "description": "Role for M2M Applications that need to act as a profile admin",
+        "specific_permissions": [
+          "profile:user.admin:*"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "lcc"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "msg-dp"}
+        ]
+      },
+      {
+        "id": "m2m-ps-sched-writer",
+        "name": "M2M Public Servant Scheduler Writer",
+        "description": "Role for M2M Applications that need to schedule tasks using Scheduler resources",
+        "specific_permissions": ["scheduler:jobs:write"],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "ogcio" },
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "abp" },
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "doe"}
+        ]
+      },
+      {
+        "id": "m2m-analytics",
+        "name": "M2M Analytics Role",
+        "description": "Role for M2M Applications that need to read from Analytics resources",
+        "specific_permissions": [
+          "analytics:website:read",
+          "analytics:website:write",
+          "analytics:website:tracking"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "03emabp0dwznxw414mxme", "organization_id": "ogcio" },
+          { "application_id": "03emabp0dwznxw414mxme", "organization_id": "abp" },
+          { "application_id": "v32qmzp9x7lh5f8kwe6ut", "organization_id": "doe"}
+        ]
+      },
+      {
+        "id": "m2m-analytics-auditor",
+        "name": "M2M Analytics Auditor Role",
+        "description": "Role for M2M Applications that need to read from Analytics audit log",
+        "specific_permissions": [
+          "analytics:audit_log:read"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "03emabp0dwznxw414mxme", "organization_id": "ogcio" },
+          { "application_id": "03emabp0dwznxw414mxme", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "m2m-citiz-journey",
+        "name": "M2M Citizen Journey Reader",
+        "description": "Role for M2M Applications that need to read from Journey resources",
+        "specific_permissions": ["journey:journey.public:read"],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "ca0c4izoo6dli4vko06g3", "organization_id": "ogcio" },
+          { "application_id": "ca0c4izoo6dli4vko06g3", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "m2m-ps-uploader",
+        "name": "M2M Public Servant Uploader",
+        "description": "Role for M2M Applications that need to interact with the Upload API",
+        "specific_permissions": ["upload:file:*"],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "der1wqp78uhshgbjyupl0", "organization_id": "ogcio" },
+          { "application_id": "der1wqp78uhshgbjyupl0", "organization_id": "abp" },
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "lcc"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "msg-dp"}
+        ]
+      },
+      {
+        "id": "m2m-otel-collector",
+        "name": "M2M Open Telemetry Collector",
+        "description": "Role for M2M Applications that need to push metrics to Open Telemetry Collector",
+        "specific_permissions": ["o11y:metrics:*"],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "628ud3kj186xzpid7zo5n", "organization_id": "ogcio" },
+          { "application_id": "628ud3kj186xzpid7zo5n", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "o11y-dashboard-admin",
+        "name": "Observability Dashboard Administrator Role",
+        "description": "Role to access as administrator observability dashboard applications",
+        "specific_permissions": ["o11y:dashboard:admin"],
+        "related_applications": [
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "ogcio" },
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "o11y-dashboard-edit",
+        "name": "Observability Dashboard Edit Role",
+        "description": "Role to access and edit observability dashboard applications",
+        "specific_permissions": ["o11y:dashboard:write"],
+        "related_applications": [
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "ogcio" },
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "o11y-dashboard-view",
+        "name": "Observability Dashboard Viewer Role",
+        "description": "Role to access  as viewer observability dashboard applications",
+        "specific_permissions": ["o11y:dashboard:read"],
+        "related_applications": [
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "ogcio" },
+          { "application_id": "yiuxr16z76vw4ssb2tjpg", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "ff-public-servant",
+        "name": "Feature Flags Unleash Role",
+        "description": "Role for Applications that need access to the Feature Flags service",
+        "specific_permissions": []
+      },
+      {
+        "id": "m2m-ps-int-reader",
+        "name": "M2M Public Servant Journey Reader",
+        "description": "Role to access journey reader api with public servant privilege",
+        "type": "MachineToMachine",
+        "specific_permissions": ["journey:journey:read"],
+        "related_applications": [
+          { "application_id": "cn49p0bq3ulq6ncodwwio", "organization_id": "ogcio" },
+          { "application_id": "cn49p0bq3ulq6ncodwwio", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "m2m-ps-payments",
+        "name": "M2M Public Servant Payments Role",
+        "description": "Role for M2M Applications that need to access payments api with public servant privilege",
+        "type": "MachineToMachine",
+        "specific_permissions": ["payments:provider:*", "payments:payment_request:*", "payments:transaction:*"],
+        "related_applications": [
+          { "application_id": "6g85tgm0k3ch1p2vjnnq2", "organization_id": "ogcio" },
+          { "application_id": "6g85tgm0k3ch1p2vjnnq2", "organization_id": "abp" }
+        ]
+      },
+      {
+        "id": "m2m-messaging",
+        "name": "M2M Messaging",
+        "description": "Role for M2M Applications that need to interact with the Messaging API",
+        "specific_permissions": [
+          "messaging:message:*",
+          "messaging:template:*"
+        ],
+        "type": "MachineToMachine",
+        "related_applications": [
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "ogcio" },
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "abp" },
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "lcc"},
+          { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "msg-dp"}
+        ]
+      },
+      {
+        "id": "formsie-ps",
+        "name": "FormsIE Admin Role",
+        "description": "Role for Applications that need access to the FormsIE service",
+        "specific_permissions": [
+          "formsie:submission:read"
+        ]
+      },
+      {
+        "id": "m2m-prf-import",
+        "type": "MachineToMachine",
+        "name": "M2M Profile Import",
+        "description": "Role used to make M2M applications able to import profiles",
+        "specific_permissions": ["profile:user.admin:write", "profile:user.admin:read"],
+        "related_applications": [
+          { "application_id": "v32qmzp9x7lh5f8kwe6ut", "organization_id": "ogcio" },
+          { "application_id": "v32qmzp9x7lh5f8kwe6ut", "organization_id": "doe"}
+        ]
+      }
+    ],
+    "applications": [
+      {
+        "name": "Payments Building Block",
+        "description": "Payments App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_PAYMENTS_APP_REDIRECT_URI>",
+        "logout_redirect_uri": [
+          "<SEEDER_PAYMENTS_APP_LOGOUT_REDIRECT_URI>",
+          "<SEEDER_PAYMENTS_APP_LOGOUT_REDIRECT_URI>/login/admin"
+        ],
+        "secret": "<SEEDER_PAYMENTS_APP_SECRET>",
+        "id": "r5f56tpkytpqyyshiutd2",
+        "is_third_party": false
+      },
+      {
+        "name": "Messaging Building Block",
+        "description": "Messaging App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_MESSAGING_APP_REDIRECT_URI>",
+        "logout_redirect_uri": ["<SEEDER_MESSAGING_APP_LOGOUT_REDIRECT_URI>", "<SEEDER_MESSAGING_APP_ADMIN_LOGOUT_REDIRECT_URI>"],
+        "secret": "<SEEDER_MESSAGING_APP_SECRET>",
+        "id": "1lvmteh2ao3xrswyq7j3e",
+        "is_third_party": false
+      },
+      {
+        "name": "Dashboard",
+        "description": "Dashboard for citizen users",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_DASHBOARD_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_DASHBOARD_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_DASHBOARD_APP_SECRET>",
+        "id": "kti441l5vjcjyenbn8f6f",
+        "is_third_party": false
+      },
+      {
+        "name": "Dashboard Admin",
+        "description": "Dashboard Admin for public servants",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_DASHBOARD_ADMIN_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_DASHBOARD_ADMIN_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_DASHBOARD_ADMIN_APP_SECRET>",
+        "id": "NXcalsHThisIIlxvnsWpY",
+        "is_third_party": false
+      },
+      {
+        "name": "Life Events",
+        "description": "Life Events App",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_LIFE_EVENTS_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_LIFE_EVENTS_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_LIFE_EVENTS_APP_SECRET>",
+        "id": "i61nya0wctzpqeyeno54z",
+        "is_third_party": false
+      },
+      {
+        "name": "Analytics Building Block",
+        "description": "Shared platform for Analytics",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_ANALYTICS_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_ANALYTICS_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_ANALYTICS_APP_SECRET>",
+        "id": "kgz1zomlw27cxx4pxh5gi",
+        "is_third_party": false,
+        "always_issue_refresh_token": true
+      },
+      {
+        "name": "Home Building Block",
+        "description": "Building Blocks home application",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_HOME_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_HOME_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_HOME_APP_SECRET>",
+        "id": "4icd76x8we31j1e8bqyfn",
+        "is_third_party": false
+      },
+      {
+        "name": "File Upload Service",
+        "description": "File Upload Service",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_UPLOAD_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_UPLOAD_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_UPLOAD_APP_SECRET>",
+        "id": "8mdj23ty5vk94w7rblxhf",
+        "is_third_party": false
+      },
+      {
+        "name": "Profile Building Block",
+        "description": "Profile App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_PROFILE_APP_REDIRECT_URI>",
+        "logout_redirect_uri": [
+          "<SEEDER_PROFILE_APP_LOGOUT_REDIRECT_URI>",
+          "<SEEDER_PROFILE_APP_LOGOUT_REDIRECT_URI>/post-global-signout"
+        ],
+        "secret": "<SEEDER_PROFILE_APP_SECRET>",
+        "id": "0921d8onfb9f3bv75trgf",
+        "is_third_party": false
+      },
+      {
+        "name": "Profile Admin Building Block",
+        "description": "Profile Admin App of Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_PROFILE_ADMIN_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_PROFILE_ADMIN_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_PROFILE_ADMIN_APP_SECRET>",
+        "id": "a68QJ2qWU9MFfLm57epsB",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Profile Reader",
+        "description": "Machine 2 Machine application used to communicate between services and Profile resource",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_PROFILE_APP_SECRET>",
+        "id": "tty6llp30risjwcjhbvc9",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Profile",
+        "description": "Machine 2 Machine application used to communicate between services and Profile resource",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_PROFILE_PS_APP_SECRET>",
+        "id": "okzj8uam29yhj4zdj21xm",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Scheduler Writer",
+        "description": "Machine 2 Machine application used to communicate between services and Scheduler resource",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_SCHEDULER_APP_SECRET>",
+        "id": "d5q7l2m9r3w1x6bp8cv0j",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Management APIs",
+        "description": "Machine 2 Machine application used to communicate with the Logto Management APIs",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_MANAGEMENT_API_APP_SECRET>",
+        "id": "46ewhh940rn1e29cmecxs",
+        "is_third_party": false,
+        "apply_management_api_role": true
+      },
+      {
+        "name": "Journey Builder Building Block",
+        "description": "Journey Builder App for Building Block",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_JOURNEY_APP_REDIRECT_URI>",
+        "logout_redirect_uri": [
+          "<SEEDER_JOURNEY_APP_LOGOUT_REDIRECT_URI>",
+          "<SEEDER_JOURNEY_APP_LOGOUT_REDIRECT_URI>/login/admin"
+        ],
+        "secret": "<SEEDER_JOURNEY_APP_SECRET>",
+        "id": "1qpp7cfssbb4mcrvmfe0c",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Journey Reader",
+        "description": "Machine 2 Machine application used to communicate between services and Journey resources",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_JOURNEY_APP_SECRET>",
+        "id": "ca0c4izoo6dli4vko06g3"
+      },
+      {
+        "name": "M2M Analytics API",
+        "description": "Machine 2 Machine application used to communicate with the Analytics APIs",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_ANALYTICS_API_APP_SECRET>",
+        "id": "03emabp0dwznxw414mxme",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Uploader",
+        "description": "Machine 2 Machine application used to communicate between services and Upload API",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_UPLOADER_APP_SECRET>",
+        "id": "der1wqp78uhshgbjyupl0",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Open Telemetry Collector",
+        "description": "Machine 2 Machine application used to communicate with the Otel Collector",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_OTEL_COLLECTOR_APP_SECRET>",
+        "id": "628ud3kj186xzpid7zo5n",
+        "is_third_party": false
+      },
+      {
+        "name": "Observability Dashboard",
+        "description": "Observability dashboard application",
+        "type": "Traditional",
+        "redirect_uri": "<SEEDER_O11Y_DASHBOARD_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<SEEDER_O11Y_DASHBOARD_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<SEEDER_O11Y_DASHBOARD_APP_SECRET>",
+        "id": "yiuxr16z76vw4ssb2tjpg",
+        "is_third_party": false
+      },
+      {
+        "name": "FF Building Block",
+        "description": "Feature Flags Service for Life Events",
+        "type": "Traditional",
+        "redirect_uri": "<FEATURE_FLAGS_UNLEASH_APP_REDIRECT_URI>",
+        "logout_redirect_uri": "<FEATURE_FLAGS_UNLEASH_APP_LOGOUT_REDIRECT_URI>",
+        "secret": "<FEATURE_FLAGS_UNLEASH_APP_SECRET>",
+        "id": "13weafp5dcznqc436mxko",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Public Servant Journey Reader",
+        "description": "Machine 2 Machine application used to communicate between services and Journey Builder resources for public servant",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_PS_JOURNEY_APP_SECRET>",
+        "id": "cn49p0bq3ulq6ncodwwio",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Public Servant Payments",
+        "description": "Machine 2 Machine application used to communicate between services and Payments API for public servant",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_PS_PAYMENTS_APP_SECRET>",
+        "id": "6g85tgm0k3ch1p2vjnnq2",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Messaging",
+        "description": "Machine 2 Machine application used to communicate between services and Messaging API",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_MESSAGING_APP_SECRET>",
+        "id": "03jn5vm2pfh3a0433p4fp",
+        "is_third_party": false
+      },
+      {
+        "name": "M2M Onboarding",
+        "description": "Machine 2 Machine application used to manage the link accounts flow",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_MESSAGING_ONBOARDING_APP_SECRET>",
+        "id": "hghygzydwvrv67j4hpmon",
+        "is_third_party": false
+      },
+      {
+        "name": "FormsIE Admin",
+        "description": "The form manager admin App",
+        "type": "SPA",
+        "redirect_uri": "http://localhost:4000/admin/auth/callback",
+        "logout_redirect_uri": "http://localhost:4000",
+        "secret": "<SEEDER_FORMSIE_APP_SECRET>",
+        "id": "66q9ecmkup9najnzajium",
+        "is_third_party": false
+      },
+      {
+        "name": "Digital Postbox M2M Profiles Exporter",
+        "description": "Machine 2 Machine application used by the digital postbox profiles exporter",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_DIGITAL_POSTBOX_M2M_PROFILE_EXPORTER_APP_SECRET>",
+        "id": "v32qmzp9x7lh5f8kwe6ut",
+        "is_third_party": false
+      },
+      {
+        "name": "Digital Postbox M2M Proxy",
+        "description": "Machine 2 Machine application used by the digital postbox proxy",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_DIGITAL_POSTBOX_M2M_APP_SECRET>",
+        "id": "r58qdwh2da6qtsqb2u5u3",
+        "is_third_party": false
+      }
+    ],
+    "resources": [
+      {
+        "id": "payments-api",
+        "name": "Payments Building Block API",
+        "indicator": "<SEEDER_PAYMENTS_API_INDICATOR>"
+      },
+      {
+        "id": "messaging-api",
+        "name": "Messaging Building Block API",
+        "indicator": "<SEEDER_MESSAGING_API_INDICATOR>"
+      },
+      {
+        "id": "scheduler-api",
+        "name": "Scheduler Building Block API",
+        "indicator": "<SEEDER_SCHEDULER_API_INDICATOR>"
+      },
+      {
+        "id": "profile-api",
+        "name": "Profile Building Block API",
+        "indicator": "<SEEDER_PROFILE_API_INDICATOR>"
+      },
+      {
+        "id": "upload-api",
+        "name": "Upload Building Block API",
+        "indicator": "<SEEDER_UPLOAD_API_INDICATOR>"
+      },
+      {
+        "id": "analytics-api",
+        "name": "Analytics Building Block API",
+        "indicator": "<SEEDER_ANALYTICS_API_INDICATOR>"
+      },
+      {
+        "id": "otel-collector-http",
+        "name": "Observability Open Telemetry Collector HTTP",
+        "indicator": "<SEEDER_OTEL_COLLECTOR_HTTP_INDICATOR>"
+      },
+      {
+        "id": "otel-collector-grpc",
+        "name": "Observability Open Telemetry Collector GRPC",
+        "indicator": "<SEEDER_OTEL_COLLECTOR_GRPC_INDICATOR>"
+      },
+      {
+        "id": "journey-api",
+        "name": "Journey Building Block API",
+        "indicator": "<SEEDER_JOURNEY_API_INDICATOR>"
+      },
+      {
+        "id": "o11y-dashboard",
+        "name": "Observability Dashboard Application",
+        "indicator": "<SEEDER_O11Y_DASHBOARD_APP_INDICATOR>"
+      },
+      {
+        "id": "formsie-sub-api",
+        "name": "FormsIE Submissions API",
+        "indicator": "<SEEDER_FORMSIE_SUBMISSIONS_API_INDICATOR>"
+      }
+    ],
+    "resource_permissions": [
+      {
+        "resource_id": "payments-api",
+        "specific_permissions": [
+          "payments:transaction.self:read",
+          "payments:payment_request.public:read",
+          "payments:transaction.self:write",
+          "payments:provider.public:read"
+        ]
+      },
+      {
+        "resource_id": "messaging-api",
+        "specific_permissions": [
+          "messaging:message.self:read",
+          "messaging:message.self:write",
+          "messaging:message:*",
+          "messaging:template:*",
+          "messaging:message.onboarding:read",
+          "profile:user.self:read",
+          "profile:user:onboarded"
+        ]
+      },
+      {
+        "resource_id": "scheduler-api",
+        "specific_permissions": ["scheduler:jobs:write"]
+      },
+      {
+        "resource_id": "profile-api",
+        "specific_permissions": [
+          "profile:user.self:read",
+          "profile:user.self:write",
+          "profile:user:read",
+          "profile:user:write",
+          "profile:user.onboarding:read",
+          "profile:user:onboarded"
+        ]
+      },
+      {
+        "resource_id": "upload-api",
+        "specific_permissions": ["upload:file.self:write", "upload:file.self:read"]
+      },
+      {
+        "resource_id": "analytics-api",
+        "specific_permissions": [
+          "analytics:website:read",
+          "analytics:website:write",
+          "analytics:website:tracking",
+          "analytics:audit_log:read"
+        ]
+      },
+      {
+        "resource_id": "otel-collector-http",
+        "specific_permissions": ["o11y:metrics:*"]
+      },
+      {
+        "resource_id": "otel-collector-grpc",
+        "specific_permissions": ["o11y:metrics:*"]
+      },
+      {
+        "resource_id": "journey-api",
+        "specific_permissions": [
+          "journey:journey.public:read",
+          "journey:journey:read",
+          "journey:run.self:read",
+          "journey:run.self:write",
+          "journey:run:write"
+        ]
+      },
+      {
+        "resource_id": "o11y-dashboard",
+        "specific_permissions": [
+            "o11y:dashboard:read",
+            "o11y:dashboard:write",
+            "o11y:dashboard:admin"
+        ]
+      },
+      {
+        "resource_id": "formsie-sub-api",
+        "specific_permissions": [
+          "formsie:submission:read"
+        ]
+      }
+    ],
+    "resource_roles": [
+      {
+        "id": "bb-citizen",
+        "name": "Citizen",
+        "description": "A citizen using Life Events and the Building Blocks ecosystem",
+        "permissions": [
+          {
+            "resource_id": "payments-api",
+            "specific_permissions": [
+              "payments:transaction.self:read",
+              "payments:payment_request.public:read",
+              "payments:transaction.self:write",
+              "payments:provider.public:read"
+            ]
+          },
+          {
+            "resource_id": "messaging-api",
+            "specific_permissions": [
+              "messaging:message.self:read",
+              "messaging:message.self:write",
+              "profile:user.self:read"
+            ]
+          },
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": [
+              "profile:user.self:read",
+              "profile:user.self:write"
+            ]
+          },
+          {
+            "resource_id": "upload-api",
+            "specific_permissions": ["upload:file.self:read"]
+          },
+          {
+            "resource_id": "journey-api",
+            "specific_permissions": [
+              "journey:journey.public:read",
+              "journey:run.self:read",
+              "journey:run.self:write"
+            ]
+          }
+        ]
+      },
+      {
+        "id": "formsie-admin",
+        "name": "FormsIE Admin",
+        "description": "A FormsIE Admin user",
+        "permissions": [
+          {
+            "resource_id": "formsie-sub-api",
+            "specific_permissions": ["formsie:submission:read"]
+          }          
+        ]
+      },
+      {
+        "id": "m2m-citizen-profile",
+        "name": "M2M Citizen Profile Reader role",
+        "description": "Role used to make M2M applications able to read from profile resource",
+        "permissions": [
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": ["profile:user:read"]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["tty6llp30risjwcjhbvc9"]
+      },
+      {
+        "id": "m2m-ps-profile",
+        "name": "M2M Public Servant Profile role",
+        "description": "Role used to make M2M applications able to read and write profile resource",
+        "permissions": [
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": [
+              "profile:user:read",
+              "profile:user:write"
+            ]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["okzj8uam29yhj4zdj21xm"]
+      },
+      {
+        "id": "m2m-messaging",
+        "name": "M2M Messaging Public Servant",
+        "description": "Role used to make M2M applications able to use Messaging service",
+        "permissions": [
+          {
+            "resource_id": "messaging-api",
+            "specific_permissions": [
+              "messaging:message:*",
+              "messaging:template:*"
+            ]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["03jn5vm2pfh3a0433p4fp"]
+      },
+      {
+        "id": "m2m-onboarding",
+        "name": "M2M Onboarding",
+        "description": "Role used to be able to link accounts",
+        "permissions": [
+          {
+            "resource_id": "messaging-api",
+            "specific_permissions": [
+              "messaging:message.onboarding:read"
+            ]
+          },
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": [
+              "profile:user.onboarding:read"
+            ]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["hghygzydwvrv67j4hpmon"]
+      },
+      {
+        "id": "m2m-citiz-journey",
+        "name": "M2M Citizen Journey Reader role",
+        "description": "Role used to make M2M applications able to read from journey resources",
+        "permissions": [
+          {
+            "resource_id": "journey-api",
+            "specific_permissions": ["journey:journey.public:read"]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["ca0c4izoo6dli4vko06g3"]
+      },
+      {
+        "id": "m2m-ps-int-reader",
+        "name": "M2M Public Servant Journey Reader role",
+        "description": "Role used to make M2M applications able to read from journey resources with public servant privilege",
+        "permissions": [
+          {
+            "resource_id": "journey-api",
+            "specific_permissions": ["journey:journey:read"]
+          }
+        ],
+        "type": "MachineToMachine",
+        "related_application_ids": ["cn49p0bq3ulq6ncodwwio"]
+      },
+      {
+        "id": "onboarded-citizen",
+        "name": "Onboarded citizen",
+        "description": "Role used to indicate if a citizen user is onboarded to the services suite",
+        "permissions": [
+          {
+            "resource_id": "profile-api",
+            "specific_permissions": ["profile:user:onboarded"]
+          },
+          {
+            "resource_id": "messaging-api",
+            "specific_permissions": ["profile:user:onboarded"]
+          }
+        ]
+      }
+    ],
+    "connectors": [
+      {
+        "id": "mygovid",
+        "sync_profile": true,
+        "connector_id": "mygovid",
+        "config": {
+          "scope": "openid profile email",
+          "clientId": "<SEEDER_MYGOVID_CONNECTOR_CLIENT_ID>",
+          "clientSecret": "<SEEDER_MYGOVID_CONNECTOR_CLIENT_SECRET>",
+          "tokenEndpoint": "<SEEDER_MYGOVID_CONNECTOR_TOKEN_ENDPOINT>",
+          "authorizationEndpoint": "<SEEDER_MYGOVID_CONNECTOR_AUTHORIZATION_ENDPOINT>",
+          "tokenEndpointAuthMethod": "client_secret_post",
+          "idTokenVerificationConfig": {
+            "jwksUri": "<SEEDER_MYGOVID_CONNECTOR_JWS_URI>"
+          },
+          "clientSecretJwtSigningAlgorithm": "HS256"
+        },
+        "metadata": {
+          "logo": "https://mygovidstatic.blob.core.windows.net/assets/images/favicon_196x196.png",
+          "name": {
+            "en": "MyGovId"
+          },
+          "target": "MyGovId (MyGovId connector)"
+        }
+      },
+      {
+        "id": "ogcio-entraid",
+        "sync_profile": true,
+        "connector_id": "ogcio-entraid",
+        "config": {
+          "clientId": "<SEEDER_ENTRAID_CONNECTOR_CLIENT_ID>",
+          "tenantId": "organizations",
+          "clientSecret": "<SEEDER_ENTRAID_CONNECTOR_CLIENT_SECRET>",
+          "cloudInstance": "https://login.microsoftonline.com"
+        },
+        "metadata": {
+          "target": "OGCIO EntraID"
+        }
+      }
+    ],
+    "sign_in_experiences": [
+      {
+        "id": "default",
+        "color": {
+          "primaryColor": "#004d44",
+          "darkPrimaryColor": "#004d44",
+          "isDarkModeEnabled": false
+        },
+        "branding": {
+          "logoUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAxODEwMCA2NDAwIj48ZyBjbGlwLXBhdGg9InVybCgjYSkiPjxwYXRoIGQ9Ik05MTQgMTc2MWE5MyA5MyAwIDEwIDAtMTg1IDkzIDkzIDAgMDAgMCAxODVabS0xNDcgMjg4MGExMDQgMTA0IDAgMTAgMCAyMDggMTA0IDEwNCAwIDAwIDAtMjA4Wk0xNzAgNDM4NWExODcgMTg3IDAgMDAgMTcgODBjODYtMzUgMTc2LTgyIDE2MC0yNzMtNy00NS0xNi05MC0yNi0xMzNhMzQwOSAzNDA5IDAgMDEtOTUtOTYwYzI0LTQ4MCAyNjAtOTIwIDM3My0xMTMwIDI0LTUwIDQzLTgwIDUyLTEwMCAzMy04MC0xMDgtMjAwLTE2NS0yNDBhMTE0IDExNCAwIDAwLTUwIDEzMCAyNTYzIDI1NjMgMCAwMC0zNzAgODYwQTI3OTMgMjc5MyAwIDAwIDAgMzM2MGMtNiAzNDcgNTAgNjk0IDE3MCAxMDIyWm0yNjYwLTIzMTdhOTUgOTUgMCAxMCAwIDE5MCA5NSA5NSAwIDAwIDAtMTkwWm0tNTc2IDE1NjRhOTIgOTIgMCAxMCAwLTE4MyA5MiA5MiAwIDAwIDAgMTgzWiIgZmlsbD0iI0EzOTE2MSIvPjxwYXRoIGQ9Ik0zMDUxIDE4NDJhMzc0IDM3NCAwIDAwLTUwLTM0MGMtMzAtMzgtNjYtNzAtMTA4LTkzLTE4My0xMjUtNDA2LTQwLTQxMy0zOGE0NTYgNDU2IDAgMDEtMzcwIDc1Yy0zNDAtODgtNjEwLTUyNi02NjAtNjEzbC0yOC0zM2E1NSA1NSAwIDAwLTMwLTE4bC02Ny00M2E0NiA0NiAwIDAwLTUzIDFsLTcgNWgtMmMtNDItNC04NSA4LTExOSAzMy00MyAzMC04NSA3NC04MCAxMThsLTg2IDY0Yy0zNSAzLTY5IDE1LTk3IDM2LTI0IDIyLTYwIDU4LTY4IDk2bC01NyA0Mi0xMCA4djVhNDMgNDMgMCAwMC03IDE1IDIzIDIzIDAgMDAtMiAxMHYxNWw1IDRjNiAxMyA0OCA5NyA3NiAxNTAtODkgODAtMTcwIDE3MC0yNDYgMjYzIDcyIDU3IDIxMSAxODYgMTYwIDMwNy0xMCAyNi0zMCA2MS01NiAxMDgtMTEwIDIwNi0zNDAgNjM2LTM2NCAxMDk2YTMzNDAgMzM0MCAwIDAwIDkxIDk0MGMxMiA0NiAyMSA5NCAyOCAxNDIgMjAgMjMzLTEwMiAzMDYtMTkzIDM0NEEyMDcwIDIwNzAgMCAwMCA1MDAgNDk3N2M4MCA5MCAxODYgMjU5IDE2NSAzNjAtMjQtMTAtNTAtMTAtNzgtNi01MCAxMS05MiA0Ny0xMTMgOTQtMzAgNjctMTggMTQ2IDMyIDIwMCA0NSA0MyAxMTIgNTMgMTkzIDI2bDIgNWMxMCAxNiAyNSAyNyA0MiAzMGg0MGMxNDYgMCAzNzctODcgNjU2LTQ5NyA5OCAxOCAxODIgMzAgMjUwIDQwbDExMCAxOGM0MyAxNiAxNDMgMTAgMjAwLTEyMGwxMTEwLTI4ODBjNjAtMTMwIDQwLTI4Ny01Ni0zOThaTTE0MzAgMTAyMGMxIDMgMjQzIDQxOCA3MDYgNTEzIDMwIDYgNjAgMTAgOTIgMTAgOTcgMCAxNzAtMzUgMjQwLTcwYTQ3MCA0NzAgMCAwMSAyMDYtNjBjMjEgMCA0MyAyIDY0IDcgMjI4IDUwIDI0NCAyODggMjQ0IDI5MGEzMyAzMyAwIDAxLTMyIDM2aC0yYTM0IDM0IDAgMDEtMzMtMzFjMC04LTE0LTE5MC0xOTItMjMwYTIyNyAyMjcgMCAwMC00OS01Yy02MCAwLTExNCAyNS0xNzYgNTUtNzQgMzUtMTU4IDc0LTI3MCA3NC0zNiAwLTcwLTQtMTA2LTEwLTQ5NC0xMDItNzQ5LTU0Mi03NTAtNTQ3YTM0IDM0IDAgMDEgNTgtMzNabTg0NiAxMDQwdi0xNzdsNDUtMTQgMzktMTV2NjNsLTg0IDE0MlptMSA0djI5NWwtODcgMTYwdi0zMDhsODctMTQ3Wm0tMzEyIDUxOS0xMzQgMjI0djQ5N2wtODcgMTYwdi01MTBsODctMTQ3di04OTBsMTcgNCA2NCA2IDUzIDJoMXY2NTFsODctMTQ3di01MDdsMzUtM2MyMC0yIDM4LTUgNTYtMTBsNDUtN3YzMDBsLTEzNiAyMjh2NDEwbC04NyAxNjBWMjU4MHYzWm0tNTgwIDk3NHYtMTc5MGw0OCAzMCA1MyAyNiAzNSAxNXYxNDkwbDk4LTE0OVYxODYwYzIwIDggNDAgMTMgNjIgMTlsNTQgMTAgMTggM1YyOTUwbC0xMzQgMjI4djU4M2wtODcgMTYwVjMzMzBsLTEzNiAyMjhabS0yMjIgMzc0di0yMTEwbDM1LTM1IDkyLTkyIDggNXYxOTk0bC0xMDQgMTc2LTMwIDUyWm00IDF2Njg0bC04NyAxNjFWNDA4MGw4Ny0xNDhabTEzMS0yMjIgODctMTQ4djY4NWwtODcgMTYwVjM3MTBaTTkwMyAxMjI1bDQ0Ni00MDBhMzQgMzQgMCAwMSA0NSA1MGwtNDI3IDM4M2M1MCA5MyAxMjIgMTc0IDIxMCAyMzNhMzQgMzQgMCAwMS0zNSA1NyA3MTIgNzEyIDAgMDEtMjQ3LTI4NSAzNCAzNCAwIDAxIDgtMzhabTExIDI3NGExNzAgMTcwIDAgMTEgMCAzMzkgMTcwIDE3MCAwIDAxIDAtMzM5Wm0xNjAgNDE1VjQwODBMODgwIDQ0MDVBMjU1MiAyNTUyIDAgMDEgNjAwIDMzNjVhMjA5NyAyMDk3IDAgMDEgNDc0LTE0NTBaTTU4OCA0NzQ1YTE4MCAxODAgMCAxMSAzNjAgMCAxODAgMTgwIDAgMDEtMzYwIDBabTU0MCAyNTdMODMwIDU1ODlhMzMgMzMgMCAwMS02MC0zMGwyOTctNTg3YTMzIDMzIDAgMTEgNjAgMzBabTI2NCAyN2EzOCAzOCAwIDAxLTYyIDEwYy0zIDAtNTctNjAtMjE4LTE5MGEzOCAzOCAwIDExIDQ4LTYwIDY0NzAgNjQ3MCAwIDAxIDE4MCAxNTAgMzQ5NzgwIDM0OTc4MCAwIDAwIDExNTYtMjg4MGM1MC0xNDIgMTIwLTIwMCAxNjgtMjI0IDQwLTIwIDg4LTIzIDEzMC0xMGEzOCAzOCAwIDExLTI1IDczIDkzIDkzIDAgMDAtNzIgMmMtNTAgMjUtOTcgOTAtMTMwIDE4MC02MyAxODItMTEzMiAyODI2LTExNzcgMjk0MFptMTI4Ni0yNjUwYTUwIDUwIDAgMTEgMCAxMDAgNTAgNTAgMCAwMSAwLTEwMFptLTEzMiAzNjFjMCAxNy0xNSAzMi0zNCAzM2EzNCAzNCAwIDAxLTMzLTM0bC0xMC0zMDBhMzQgMzQgMCAxMSA2NSAwbDQgMzAwWm0tMTI3IDQ1Wm0tMzAzIDk5OGE1MCA1MCAwIDExLTUwIDUwYzAtMjggMjItNTAgNTAtNTBabS01MDkgOTM2YTM0IDM0IDAgMTEtNTItNDJsMjg1LTM1N2EzMyAzMyAwIDAxIDI2LTEzIDMzIDMzIDAgMDEgMjYgNTRsLTI4NSAzNjBabTIwMSAyNWE1MCA1MCAwIDExLTEwMCAwIDUwIDUwIDAgMDEgMTAwIDBabS02OS01NDBhNTAgNTAgMCAxMSA1MCA1MCA1MCA1MCAwIDAxLTUwLTUwWm0tNjAgODM4YTUwIDUwIDAgMTEgMC0xMDAgNTAgNTAgMCAwMSAwIDEwMFptMjE1IDY3YTI4IDI4IDAgMTEtNTQtMTUgMTc2IDE3NiAwIDEwLTM0Ni02NyAyOCAyOCAwIDAxLTU1LTd2LTJhMjMzIDIzMyAwIDExIDQ1NiA5MlptNDItMTI5NGMxOSAwIDM0IDEzIDM0IDMybDQgMzA1YzAgMTgtMTUgMzMtMzMgMzNhMzQgMzQgMCAwMS0zNC0zM2wtNC0zMDVjMC0xOCAxNS0zMyAzMy0zM1ptLTMyIDQ1NWE1MCA1MCAwIDExIDEwMCAxIDUwIDUwIDAgMDEtMTAwIDBabTkyIDY2MWMwIDIwLTE1IDM0LTMzIDM0YTM0IDM0IDAgMDEtMzQtMzVsMTEtNTQzYzAtMTggMTYtMzIgMzQtMzIgMTggMCAzMyAxNSAzMyAzNGwtMTAgNTQzWm0xMjAtNTQ4YTUwIDUwIDAgMTEgMC05OSA1MCA1MCAwIDAxIDAgMTAwWm0yNzMtNTI0LTM0MiAzNTJhMzMgMzMgMCAxMS00OC00OGwzNDItMzUzYTM0IDM0IDAgMDEgNTAgNDdaTTIyNTUgMzcwMGExNjggMTY4IDAgMTEgMC0zMzYgMTY4IDE2OCAwIDAxIDAgMzM3Wm0xMjQtNDIxYTUwIDUwIDAgMTEgMC0xMDAgNTAgNTAgMCAwMSAwIDEwMFptODUtMzMwLTI1MyAzMjBhMzQgMzQgMCAwMS01My00M2wyNTQtMzIwYTMzIDMzIDAgMDEgMjYtMTIgMzMgMzMgMCAwMSAyNiA1NlptOC0xMDBhNTAgNTAgMCAxMSA1MiA1MCA1MCA1MCAwIDAxLTUwLTUwWm0xMDAgNjMyYTM1IDM1IDAgMDEtMzMgMzMgMzQgMzQgMCAwMS0zNC0zNGwxMC00OTIgMS03di0zYzAtMTAgOC0xNyAxNy0yMGwxNi0yYzE4IDAgMzMgMTUgMzMgMzNsLTEwIDQ5NFptMTAwLTUyMmE1MCA1MCAwIDExIDAtMTAwIDUwIDUwIDAgMDEgMCAxMDBabTI5Mi01MDAtMzQ0IDM2MGEzMyAzMyAwIDAxLTQ3IDAgMzMgMzMgMCAwMS0xMC0zNCAyMCAyMCAwIDAxIDYtMTVsMzQzLTM1MmExOSAxOSAwIDAxIDEwLTUgMzMgMzMgMCAwMSA0MCA1M1ptLTEzMC0xMzRhMTcxIDE3MSAwIDExIDE3MC0xNzBjMCA5My03NSAxNzAtMTcwIDE3MFoiIGZpbGw9IiNBMzkxNjEiLz48cGF0aCBkPSJNNDM3MCAwYTE2ODc3MiAxNjg3NzIgMCAwMCAwIDY0MDBoNTFhMTY4NzczIDE2ODc3MyAwIDAwIDAtNjQwMGgtNTFabTIxNDAgMzExNWMtODYgMC0xOTItNDMtMjUyLTEwMS04MS04MC0xMDEtMTEyLTIwNS0zNDBsLTQ1IDNjLTEwIDAtMjIgMC00MC00djE4M2MwIDEwNSAyMCAxMzAgMTIwIDE0OHYzMGgtNDM3di0zMGMxMTQtMTMgMTQwLTQwIDE0MC0xNDhWMjM2MGMwLTEwNC0yMy0xMzgtMTIwLTE3MXYtMjlsMjcwIDE1YTkwMCA5MDAgMCAwMSAxNzYtMTljMTU2IDAgMjUwIDg1IDI1MCAyMjYgMCA0MC03IDc2LTIyIDEwNS0yNCA1MC01NyA4My0xNDMgMTQ0IDEzNSAyMTcgMjAwIDMxMCAyNjMgMzcwIDQ1IDUwIDk2IDczIDE2NSA4M3YyMGEzOTAgMzkwIDAgMDEtMTEwIDE3Wm0tNTQyLTg5N3YzNzdhMjE2IDIxNiAwIDAwIDE1MCAxMGwyNC0zMGMzMC00MiA0Ny05MiA0Ny0xNDkgMC0xMjYtNzAtMTkyLTIyMS0yMDhaIiBmaWxsPSIjMDA0RDQ0Ii8+PHBhdGggZD0iTTY1NTcgMzAzM3YtMjljMTgtNSAzMS0xMCA0Mi0xNyAyNC0xOCAzMC0zNCAzMi0xMjJsMTAtMjYwdi0xMGEzMDAgMzAwIDAgMDAtMTAtODhjMC0yMS0yMC0zMC01MC00M3YtMjdsMTkwLTM4IDQ3IDgtMTAgMTY4djI4MGMtMSAxMDcgNyAxMjIgNjUgMTQwdjI5aC0zMTBabTE2OC03NjVjLTYzIDAtMTEzLTQ1LTExMy0xMDEgMC01MiA1MC05NCAxMTMtOTQgNjAgMCAxMTAgNDIgMTEwIDk0IDAgNTYtNTAgMTAwLTExMCAxMDBabTYxOCA3NzhoLTJjLTQ2IDAtNzAtMTYtOTAtNjAtNjIgNTItOTggNjYtMTYwIDY2LTk0IDAtMTU2LTU2LTE1Ni0xMzggMC0zMSA4LTYwIDIzLTgzIDE4LTI4IDQ1LTQ0IDExNi02OWwxODctNjR2LTg0bC0zLTc1YzAtNTItMTAtNjYtNTAtNjYtNDYgMC03MyAyMy0xMDAgODdsLTM0IDcxaC0zOGMtNDYgMC03NC0xOS03NC01MiAwLTMwIDI0LTY3IDY1LTk2IDcwLTUzIDE1NS04MCAyNTItODAgMTAwIDAgMTM4IDM3IDEzOCAxMjh2MTdsLTEwIDI5NHYxMGMwIDc0IDE3IDk4IDk0IDEzNXYzNmMtNTkgMTQtMTA5IDIzLTE1MCAyM1ptLTkxLTI4OC05NCA0MmMtNTQgMjUtNzUgNTAtNzUgOTAgMCA0NCAzMiA3MyA4MCA3MyAyNCAwIDU0LTUgOTAtMTR2LTE5MFptMjg0IDI3NXYtMjljNTgtMTIgNzAtMzUgNzQtMTM5bDEwLTI2MHYtMjUyYzAtMTEwLTMtMTM1LTE0LTE3MS03LTI1LTE1LTM2LTQzLTUzVjIxMDBsMjAwLTM2IDMzIDI3YTE2NzAgMTY3MCAwIDAwLTE5IDMzMHY0NDRjMCAxMDcgMTggMTMwIDcyIDE0MHYyOGgtMzEzWm02MDAgMjBjLTExMCAwLTE3My01Ny0xNzAtMTU5bDEwLTM0Ni02Ni04NHYtMzdjNTUtMjAgNzYtMzMgMTE1LTczIDI1LTI0IDM2LTM3IDYyLTc3bDY1IDMwLTIwIDEyNCAxMTMtMTBjMzQgOSA1NSAyOSA1NSA1OSAwIDM0LTMwIDYwLTc0IDYwaC05M3YzMTZjMCA1NyAxMCA4MyAzNSAxMDAgMjQgMTYgNTEgMjIgMTIzIDIybDEwIDI4Yy02MCA0NC05NCA1Ny0xNTQgNTdabTYyMi03aC0yYy00NiAwLTcwLTE2LTkwLTYwLTczIDUyLTExMCA2Ni0xNzAgNjYtOTQgMC0xNTctNTYtMTU3LTEzOCAwLTMwIDEwLTYwIDIzLTgzIDIwLTI4IDQ2LTQ0IDExOC02OWwxODYtNjR2LTg0bC0yLTc1Yy0yLTUyLTEwLTY2LTUwLTY2LTQ2IDAtNzMgMjMtMTAyIDg3bC0zMiA3MWgtMzhjLTQ2IDAtNzQtMTktNzQtNTIgMC0zMCAyNC02NyA2NS05NiA3MS01MyAxNTctODAgMjU0LTgwIDk4IDAgMTM4IDM3IDEzOCAxMjh2MTdsLTEwIDI5NHYxMGMwIDc0IDE2IDk4IDkzIDEzNXYzNmE2NzAgNjcwIDAgMDEtMTUwIDIzWm0tOTItMjg4LTkzIDQyYy01NCAyNS03NSA1MC03NSA5MCAwIDQ0IDMyIDcyIDgwIDcyIDI0IDAgNTMtNCA4OC0xM3YtMjAwWm01NjAgMjg4Yy01NyAwLTk3LTQtMjI2LTI3bC0xOS0xODIgMzctMTBjNjUgODAgOTIgMTA3IDEyNyAxMzMgMjAgMTYgNTMgMjggNzMgMjggNDMgMCA3Ny0zNSA3Ny03OGE3MCA3MCAwIDAwLTgtMzQgNjYgNjYgMCAwMC0yNi0yOGwtNTYtMzAtNzUtMzdjLTExMC01NC0xNTItMTA4LTE1Mi0xOTAgMC0xMTQgODctMTg4IDIyMi0xODggNjEgMCA5NiA3IDE4MiAzNGwxOCAxNDAtMzcgMThhNTIwIDUyMCAwIDAwLTEwMi0xMDcgMTMwIDEzMCAwIDAwLTcwLTI1IDc2IDc2IDAgMDAtODAgNzVjMCAzOCAyNSA2NCA4NCA5NGwxMTIgNTZjOTYgNDkgMTMxIDkyIDEzMSAxNjYgMCAxMTctODUgMTkyLTIxMyAxOTJabTk0Ny0xM3YtMjljNjAtMTIgNzItMzMgNzYtMTM5di0yNDBjMC04My00MC0xMjYtMTE1LTEyNi0zMCAwLTUzIDctMTAwIDMxdjMzNWMwIDEwNyA4IDEyNyA1NSAxNDB2MjhIOTgwMHYtMjljNTgtMTIgNzAtMzUgNzQtMTM5bDEwLTI2MHYtMTNjMC03OC0xNS0xMDQtNzYtMTI4di0yN2wyMzQtMzh2ODBjODYtNzAgMTI4LTgwIDIxMy04MCAxMTAgMCAxNjAgNTAgMTYwIDE2MHYyOTdjMCA5NyAxMCAxMjIgNjQgMTQwdjMwaC0zMDhabTc4OCAxM2gtMmMtNDYgMC03MC0xNi05MC02MC03MiA1Mi0xMDkgNjYtMTcwIDY2LTk0IDAtMTU2LTU2LTE1Ni0xMzggMC0zMCA4LTYwIDIzLTgzIDIwLTI4IDQ1LTQ0IDExNy02OWwxODYtNjR2LTg0bC0yLTc1Yy0yLTUyLTEwLTY2LTUwLTY2LTQ2IDAtNzMgMjMtMTAwIDg3bC0zNCA3MWgtMzhjLTQ2IDAtNzQtMTktNzQtNTIgMC0zMCAyNC02NyA2NS05NiA3Mi01MyAxNTctODAgMjU0LTgwIDEwMCAwIDEzOCAzNyAxMzggMTI4djE3bC0xMCAyOTR2MTBjMCA3NCAxNiA5OCA5MyAxMzV2MzZhNjcwIDY3MCAwIDAxLTE1MCAyM1ptLTkyLTI4OC05MyA0MmMtNTQgMjUtNzUgNTAtNzUgOTAgMCA0NCAzMiA3MyA4MCA3MyAyNCAwIDUzLTUgODgtMTR2LTE5MFptOTM3IDI3NXYtMjljNTgtMjAgNzAtNDIgNzQtMTM5bDEwLTIyNGMwLTkzLTMxLTEyOS0xMDctMTI5LTMyIDAtNTUgNi0xMDggMjh2MzM1YzAgOTYgMTAgMTIyIDU2IDE0MHYyOGgtMjk4di0yOWM2NC0xMyA3MC0yNyA3NS0xMzlsMTAtMjYwdi0zNTBjLTEtNzgtMTctMTAzLTc1LTEyNnYtMzBsMjEzLTM2IDM4IDM2LTIwIDM4M2M5MC02NSAxMzgtODQgMjEwLTg0IDUwIDAgOTAgMTQgMTIwIDQwIDMwIDIzIDQ0IDYwIDQ0IDEzMHYzMDBjMCAxMDYgNyAxMjIgNjUgMTM3djMwaC0zMDdabTk4MCAwaC02NDV2LTI5YzExMy0xNSAxNDAtNDMgMTQwLTE0OFYyMzYwYzAtMTEyLTE3LTE0MC0xMDItMTY3di0yN2g1ODdsMjAgMjA0LTMwIDEwYy02MC0xMDgtMTA0LTE0MS0xOTYtMTUwbC0xMDItOXYzMzVsOTMtNGM5Ni00IDExNi0yMCAxNDAtMTA3aDMwdjI4MGgtMzBjLTI3LTg0LTUyLTEwNC0xNDAtMTA4bC04Mi00djIyM2MwIDEwMCAyNyAxMzEgMTEzIDEzMSAxMDAgMCAxNjAtNDUgMjQwLTE3N2wyOCAxOC01NSAyMjRabS0xNDctOTc4LTI2MCA0NS0xMC0xNyAyMzAtMTQwIDYwIDQ3LTI5IDY1Wm0yNzcgOTc4di0yOWMxOC01IDMxLTEwIDQyLTE3IDI0LTE4IDMwLTM0IDMyLTEyMmwxMC0yNjB2LTEwYzAtMzQtNi02OS0xMi04OC0xMC0yMC0yMi0zMC01NC00M3YtMjdsMTg2LTM4IDQ3IDEwLTEwIDE2NnYyODBjMCAxMDcgOCAxMjIgNjYgMTQwdjMwaC0zMDdabTE2OC03NjVjLTYzIDAtMTEzLTQ1LTExMy0xMDAgMC01MyA1MC05NSAxMTMtOTUgNjAgMCAxMTAgNDIgMTEwIDk0IDAgNTYtNTAgMTAwLTExMCAxMDBabTYyNCAzNTVjLTQyLTM0LTgzLTUyLTExNC01Mi0yMCAwLTQwIDE0LTYzIDQ3djI0N2MwIDk2IDIwIDEyMCAxMjEgMTQwdjI4aC0zNjN2LTI5YzYwLTIwIDcwLTQwIDcwLTEzOWwxMC0yODB2LTZjMC03MC0yMC0xMDAtODAtMTIwdi0zMGwyMzItNDAtNiAxNDBoNmM1NC05OSA5Ny0xNDAgMTUwLTE0MCA0MSAwIDcwIDQwIDcwIDk3IDAgNDQtOCA3MC00MyAxMjdabTU5MyA3NWgtMzU0djE0YzAgNjAgMiA3MCAxMCAxMDYgMjAgODIgODYgMTMwIDE4OCAxMzAgNTAgMCA4MC02IDE0Ny0zNmwyMCAxMGMtOCAyMC0xNCAzNi0xOSA0MmEzNDAgMzQwIDAgMDEtMjQ2IDkzYy0xNTAgMC0yNTctMTI4LTI1Ny0zMDUgMC0yMDYgMTIyLTM1NCAyOTUtMzU0IDEzOCAwIDIyOCA3NSAyMjggMTkxIDAgMjgtNCA2NC0xMiAxMTBabS0xNTItMTkwYTc3IDc3IDAgMDAtNzMtNDRjLTM1IDAtNjggMTYtOTIgNDctMjIgMzAtMzAgNTMtMzcgMTEyaDE5NmwxOC0xOWMwLTU4LTMtNzQtMTItOTdabTY0MyA1MzhoLTNjLTQ2IDAtNzAtMTYtOTAtNjAtNzIgNTItMTA5IDY2LTE3MCA2Ni0xMDAgMC0xNjAtNTYtMTYwLTEzOCAwLTMwIDItNjAgMjAtODMgMjAtMjggNDMtNDQgMTE0LTY5bDE4OC02NHYtODRsLTMtNzVjMC01Mi0xMC02Ni01MC02Ni00NiAwLTczIDIzLTEwMCA4N2wtMzQgNzFoLTM1Yy00NiAwLTc1LTE5LTc1LTUyIDAtMzAgMjUtNjcgNjUtOTYgNzItNTMgMTU3LTgwIDI1NC04MCAxMDAgMCAxMzggMzcgMTM4IDEyOHYxN2wtMTAgMjk0djEwYzAgNzQgMTcgOTggOTQgMTM1djM2YTY3MCA2NzAgMCAwMS0xNTAgMjNabS05Mi0yODgtOTMgNDJjLTU0IDI1LTc2IDUwLTc2IDkwIDAgNDQgMzIgNzMgODEgNzMgMjMgMCA1My01IDg4LTE0di0xOTBabTY2NSAyNzV2LTI5YzYwLTEyIDcyLTMzIDc2LTEzOWwxMC0yMzR2LTZjMC04My00MC0xMjYtMTE2LTEyNi0zMCAwLTUzIDctMTAwIDMxdjMzNWMwIDEwNyA4IDEyNyA1NiAxNDB2MjhoLTI5OHYtMjljNTgtMTIgNzAtMzUgNzUtMTM5bDEwLTI2MHYtMTNjMC03OC0xNi0xMDQtNzctMTI4di0yN2wyMzQtMzh2ODBjODctNzAgMTMwLTgwIDIxNC04MCAxMTAgMCAxNjAgNTAgMTYwIDE2MHYyOTdjMCA5NyAxMCAxMjIgNjQgMTQwdjMwaC0zMDhabTc0NiAwdi0yOWM2MC0xMiA3Mi0zMyA3Ni0xMzlsMTAtMjM0di02YzAtODMtNDAtMTI2LTExNi0xMjYtMzAgMC01MiA3LTEwMCAzMXYzMzVjMCAxMDcgOCAxMjcgNTYgMTQwdjI4aC0yOTd2LTI5YzU3LTEyIDcwLTM1IDc0LTEzOWwxMC0yNjB2LTEzYzAtNzgtMTYtMTA0LTc2LTEyOHYtMjdsMjMzLTM4djgwYzg3LTcwIDEzMC04MCAyMTQtODAgMTEwIDAgMTYwIDUwIDE2MCAxNjB2Mjk3YzAgOTcgMTAgMTIyIDY0IDE0MHYzMGgtMzA4Wm0tOTY1MCAxMTM1djk0bDIxIDEzMGgtNDNjLTE2IDAtMjMgMC0xMjUgMzMtNTAgMTUtMTEwIDIzLTE3OSAyMy0xMzggMC0yMTktMjgtMjk3LTEwMmE0NjQgNDY0IDAgMDEtMTQwLTM0MmMwLTEyNyA0NC0yNDggMTIxLTMzMGE0MjAgNDIwIDAgMDEgMzMyLTEzMGM5MCAwIDE1MCAxMCAyODMgNTZsMTAgMjA1LTI4IDE5QzYzMzAgMzY1NCA2MjYwIDM2MDAgNjEyNyAzNjAwYy0xNzMgMC0yOTAgMTU4LTI5MCAzOTEgMCAyMzIgMTMzIDM5MiAzMjQgMzkyIDEyNSAwIDE5MC01MSAxOTAtMTUwdi01NWMwLTk2LTI3LTEyNC0xMzAtMTQ1di0zMmgzNDR2MjdjLTg0IDI3LTEwMyA1My0xMDMgMTQwWm00NzYgMjgwYy0xNjYgMC0yNjAtMTA3LTI2MC0yOTQgMC0yMjUgMTI1LTM2MiAzMjYtMzYyIDE2NiAwIDI2MCAxMDUgMjYwIDI5NCAwIDIyNC0xMjQgMzYyLTMyNiAzNjJabTMwLTYwMGMtMTAwIDAtMTcwIDEwNy0xNzAgMjYwIDAgMTY2IDc0IDI4NSAxNzYgMjg1IDEwMCAwIDE3MC0xMTAgMTcwLTI2NSAwLTE2My03NC0yODAtMTc3LTI4MFptODkzIDNjLTE1IDEwLTM0IDQwLTQ2IDY2bC0yMDUgNDc0Yy0yMCA0NC0zOCA2Ny01NyA2N2gtNGwtMTczLTU0MGMtMTItMzktMzAtNjItNjUtNzV2LTI5aDI0MnYzMGwtMjcgN2MtMzAgMTAtNDIgMjMtNDIgNDggMCAxNCA0IDM2IDE0IDY0TDc2MDAgNDI4MWwxMTItMzAwYzEyLTMxIDE4LTYwIDE4LTgwIDAtMzMtMjctNTAtODQtNTR2LTMzaDIzNHYzMGwtMjAgN1ptMzAzIDU5M2MtMTQwIDAtMjM4LTEyMy0yMzgtMzAwIDAtMjEzIDExNi0zNDQgMzAxLTM0NCAxMjMgMCAxOTMgNjIgMTkzIDE3MCAwIDI2LTEwIDYxLTEwIDEwMGgtMzkwdjM1YzAgMTUzIDczIDI0MyAyMDAgMjQzIDUwIDAgODAtOCAxNzAtNDBsMjQgNWMtMTcgNjgtMTQzIDEzMC0yNjAgMTMwWm0xNTQtNDgwYzAtNTgtNTAtMTA0LTExNS0xMDQtNzYgMC0xMzQgNTQtMTY1IDE1NGgyNjBsMjAtMjN2LTI4Wm01OTMtMjAtMTAgMTZhMjIzIDIyMyAwIDAwLTk4LTI4Yy0zNyAwLTY2IDI3LTk5IDg1djIzNWMwIDEwNyAzMCAxMzUgMTUwIDE0NXYzMmgtMzQ2di0zMmM2OC0xOCA4MS00MCA4NS0xNDVsOC0yMjRjMi04IDItMTYgMi0yNCAwLTkyLTEwLTExMi03Ni0xNDR2LTI3bDE3Ny0zN3YxNTRjOTctMTI2IDEyNy0xNDggMTk3LTE0OCAyNSAwIDQ0IDIwIDQ0IDQzIDAgMzAtMTIgNjMtMzQgOThabTQ0NCA0ODV2LTMyYzc0LTEyIDkwLTM0IDkzLTE0NWwxMC0yMjR2LThjMC04NC00My0xMzUtMTEyLTEzNS00NiAwLTc4IDEwLTE2MCA1MHYzMTdjMCA0OSA1IDgzIDEwIDk4IDEwIDI0IDM2IDM3IDg0IDQ3djMyaC0yOTB2LTMyYzcwLTE4IDgyLTM4IDg2LTE0NWw4LTIyNGMyLTUgMi0xMiAyLTIwIDAtOTAtMTctMTIxLTc2LTE0OHYtMjdsMTYzLTQxIDE0IDh2OTNjMTE4LTc0IDE3Mi05NyAyMzYtOTcgMzYgMCA4MCAxNiAxMDAgMzcgMjUgMjUgMzcgNjggMzcgMTMwdjI5MGMwIDEwOSA4IDEyMCA4NCAxNDR2MzJoLTI5MFptMTExMCAwdi0zMmM3My0xMiA5MC0zNCA5Mi0xNDVsMTAtMjI0di0xMGMwLTgyLTQyLTEzNS0xMDctMTM1LTQ1IDAtNzYgMTQtMTY0IDY3djMwMmMwIDQ5IDQgODMgMTAgOTcgMTAgMjUgMzUgMzggODQgNDh2MzJoLTI5OXYtMzJjNzYtMTIgOTAtMzQgOTMtMTQ1bDEwLTIyNHYtMTBjMC04Mi00MC0xMzUtMTA3LTEzNS00MCAwLTYwIDctMTY0IDUydjMxN2MwIDQ5IDQgODIgMTAgOTcgMTAgMjUgMzUgMzggODQgNDh2MzJoLTI5MHYtMzJjNzAtMTggODItMzggODYtMTQ1bDgtMjI0IDEtMjVjMC05MS0xMC0xMTItNzYtMTQzdi0yN2wxNjgtMzggMTAgMTB2ODhjMTE2LTc1IDE3Mi05OCAyNDMtOTggNzEgMCA5OCAyNSAxMzAgMTEyIDEwNS04NiAxNjAtMTEyIDIzNy0xMTIgNDMgMCA4MyAyMCAxMDcgNDggMjAgMjQgMjggNjAgMjggMTIwdjI5MGMwIDEwOSA4IDEyMiA4NCAxNDR2MzJoLTI5MFptNjIwIDE1Yy0xNDAgMC0yMzgtMTIzLTIzOC0zMDAgMC0yMTMgMTE2LTM0NCAzMDEtMzQ0IDEyMyAwIDE5MyA2MiAxOTMgMTcwIDAgMjYtMyA2MS0xMCAxMDBoLTM4MnYzNWMwIDE1MyA3NSAyNDMgMjAwIDI0MyA1MCAwIDgxLTggMTcwLTQwbDI2IDVjLTE2IDY4LTE0MiAxMzAtMjYwIDEzMFptMTUzLTQ4MGMwLTU4LTUwLTEwNC0xMTUtMTA0LTc1IDAtMTMzIDU0LTE2NCAxNTRoMjYwbDIwLTIzdi0yOFptNTU1IDQ2NXYtMzJjNzQtMTIgOTAtMzQgOTMtMTQ1bDEwLTIyNHYtOGMwLTg0LTQyLTEzNS0xMTAtMTM1LTQ3IDAtODAgMTAtMTYwIDUwdjMxN2MwIDQ5IDMgODMgMTAgOTggMTAgMjQgMzQgMzcgODIgNDd2MzJoLTI4OXYtMzJjNzAtMTggODEtMzggODUtMTQ1bDEwLTIyNHYtMjBjMC05MC0xNi0xMjEtNzYtMTQ4di0yN2wxNjQtNDEgMTMgOHY5M2MxMTgtNzQgMTcyLTk3IDIzNy05NyAzNSAwIDc4IDE2IDEwMCAzNyAyNCAyNSAzNiA2OCAzNiAxMzB2MjkwYzAgMTA5IDggMTIwIDg0IDE0NHYzMmgtMjkwWm01ODAgMTRjLTEwNSAwLTE1MC00Mi0xNDYtMTUybDgtMzY4LTY0LTcyIDQtMzZhMjkwIDI5MCAwIDAwIDEzOC0xNDBsMzYgMTQtMTAgMTQwIDE2Ny0xMGMyNS0yIDM4IDEyIDM4IDMzIDAgMzAtMjcgNTAtNjUgNTBoLTE0MHYzMzBjMCA5MCAzMCAxNDIgODcgMTQyIDMxIDAgNzItMTIgMTE4LTM0bDEwIDI5Yy02NyA2Mi05OCA3NC0xODAgNzRabTc0OCA1Yy0xNjYgMC0yNjAtMTA3LTI2MC0yOTQgMC0yMjUgMTI1LTM2MiAzMjctMzYyIDE2NiAwIDI2MCAxMDUgMjYwIDI5NCAwIDIyNC0xMjQgMzYyLTMyNyAzNjJabTMwLTYwMGMtOTkgMC0xNjkgMTA3LTE2OSAyNjAgMCAxNjYgNzMgMjg1IDE3NiAyODUgMTAwIDAgMTcwLTExMCAxNzAtMjY1IDAtMTYzLTc0LTI4MC0xNzctMjgwWm05MDQtMjU0Yy02MC01OC0xMDAtNzgtMTUwLTc4LTU0IDAtOTAgMjYtMTIwIDg0LTIzIDQyLTI4IDc3LTM1IDE3MGwtNCA1OCAxNjgtMTBjMjQgMCAzNyAxNCAzNyAzNiAwIDM2LTEwIDQ0LTU1IDQ0aC0xNTBsMTAgMzU0YzAgNDIgMyA3MCAxMCA4NCAxMSAzMiA1MCA1MSAxMjEgNjB2MzNoLTMzN3YtMzJjNzQtMTIgOTMtNDMgOTMtMTQ1di0zMjBsLTgzLTYydi0yMGw5MC01NmM4LTEzNiAyOC0xOTMgOTItMjU2IDUwLTUyIDEyMy04MCAyMTAtODAgMTEyIDAgMTc2IDI0IDE3NiA2MyAwIDM1LTIzIDU3LTczIDczWm0xODcgODM1di0yOGMxMDgtMTYgMTMwLTQyIDEzMC0xNDlWMzc0MGMwLTEwNC0yMC0xMzAtMTIwLTE1MHYtMjdoMzYzdjI3Yy0xMDggMTgtMTMwIDQzLTEzMCAxNTB2NTEyYzAgMTA3IDIyIDEzMyAxMzAgMTQ5djI4aC0zNzNabTg1MC00ODYtMTIgMTdhMjIwIDIyMCAwIDAwLTk3LTI4Yy0zNyAwLTY3IDI3LTEwMCA4NXYyMzVjMCAxMDcgMzAgMTM1IDE1MCAxNDV2MzJoLTM0NXYtMzJjNjctMTggODEtNDAgODUtMTQ1bDgtMjI0IDEtMjRjMC05Mi0xMC0xMTItNzUtMTQ0di0yN2wxNzctMzd2MTU0Yzk3LTEyNiAxMjctMTQ4IDE5Ny0xNDggMjQgMCA0MyAyMCA0MyA0M2EyMDAgMjAwIDAgMDEtMzMgOThabTMyNiA1MDFjLTE0MCAwLTIzOC0xMjMtMjM4LTMwMCAwLTIxMyAxMTYtMzQ0IDMwMS0zNDQgMTIzIDAgMTkzIDYyIDE5MyAxNzBhNTAwIDUwMCAwIDAxLTEwIDEwMGgtMzgwdjM1YzAgMTUzIDczIDI0MyAyMDAgMjQzIDUwIDAgODAtOCAxNjctNDBsMjcgNWMtMTYgNjgtMTQwIDEzMC0yNjAgMTMwWm0xNTQtNDgwYzEwLTU4LTQwLTEwNC0xMDQtMTA0LTc2IDAtMTM0IDU0LTE2NSAxNTRoMjYwbDIxLTIzdi0yOFptMTg4IDQ2NXYtMzJjNzMtMTIgOTAtMzUgOTItMTQ1bDEwLTI2MHYtMjYwYzAtMTQwLTEwLTE3MS02NS0xOTZ2LTQwbDE2Ny0yNiAyMSAxOC0yMCAzNDV2NDIwYzAgNDggMyA4MiAxMCA5NyAxMCAyNCAzNCAzNyA4NCA0N3YzMmgtMzAwWm04NTAgNmMtMjAgMi00MCA1LTU4IDUtNTUgMC03My0xNS04OS02OS04MCA1OC0xMTkgNzItMTkwIDcyLTkwIDAtMTQ1LTQ5LTE0NS0xMjkgMC02NyAzNy0xMDUgMTQwLTE0M2wyMDQtNzZ2LTExM2MxLTg4LTIwLTExMy05NC0xMTMtNjggMC05NSAyNC0xMjkgMTEzbC0yMCA0NmMtNTAtNy03NC0yNC03NC01NCAwLTQ2IDc0LTExMiAxNjYtMTQ3IDQwLTE1IDEwMC0yNyAxMzctMjcgODUgMCAxMjEgMzcgMTIxIDEyNHYyNmwtMTMgMzE2djEwYzAgNjcgMjAgODggMTEwIDEyMHYzMGwtNjcgMTBabS0yNzUtMjM3Yy02MiAyNi05MiA1OC05MiAxMDAgMCA0MCAzNSA3NiA3NiA3NiAyNCAwIDYwLTggMTAzLTI0bDQwLTE0IDEwLTE5NS0xMzggNTdabTc3MCAyMzF2LTMyYzc0LTEyIDkwLTM0IDkzLTE0NWwxMC0yMjR2LThjMC04NC00My0xMzUtMTEwLTEzNS00OCAwLTgwIDEwLTE2MCA1MHYzMTdjMCA1MCAzIDgzIDEwIDk4IDggMjQgMzMgMzcgODIgNDd2MzJoLTI5MHYtMzJjNzAtMTggODItMzggODYtMTQ1bDctMjI0IDEtMjBjMC05MC0xNi0xMjEtNzUtMTQ4di0yN2wxNjMtNDEgMTQgOHY5M2MxMTgtNzQgMTcyLTk3IDIzNy05NyAzNSAwIDgwIDE2IDEwMCAzNyAyNSAyNSAzNyA2OCAzNyAxMzB2MjkwYzAgMTA5IDggMTIwIDg0IDE0NHYzMmgtMjkwWm04MzAgMjAtMTktMjB2LTY1Yy03MCA2MC0xMjQgODQtMTkzIDg0LTEzOSAwLTIzNS0xMjMtMjM1LTMwMCAwLTIwMCAxMzAtMzUyIDMwMC0zNTIgNDQgMCA3MCA1IDEzMCAyOHYtMTAwYzEtMTM5LTIwLTE3OC0xMDktMTk5di0zMmwyMTAtMjMgMjEgMTctMjAgMzI3djQzOGMwIDg0IDE1IDEwNiA4NiAxMjZ2MzJsLTE3MCAzOFptLTE5LTQ0OGMwLTg3LTQ4LTE0NS0xMjAtMTQ1LTExMCAwLTE5OCAxMDctMTk4IDI0MiAwIDE1NSA4MiAyNjAgMjA0IDI2MCA0MiAwIDYzLTUgMTEzLTMydi0zMjVaIiBmaWxsPSIjMDA0RDQ0Ii8+PC9nPjxkZWZzPjxjbGlwUGF0aCBpZD0iYSI+PHBhdGggZD0iTTAgMGgxODA5M3Y2NDAwSDAiIGZpbGw9IiNmZmYiLz48L2NsaXBQYXRoPjwvZGVmcz48L3N2Zz4K",
+          "darkLogoUrl": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAxODEwMCA2NDAwIj48ZyBjbGlwLXBhdGg9InVybCgjYSkiPjxwYXRoIGQ9Ik05MTQgMTc2MWE5MyA5MyAwIDEwIDAtMTg1IDkzIDkzIDAgMDAgMCAxODVabS0xNDcgMjg4MGExMDQgMTA0IDAgMTAgMCAyMDggMTA0IDEwNCAwIDAwIDAtMjA4Wk0xNzAgNDM4NWExODcgMTg3IDAgMDAgMTcgODBjODYtMzUgMTc2LTgyIDE2MC0yNzMtNy00NS0xNi05MC0yNi0xMzNhMzQwOSAzNDA5IDAgMDEtOTUtOTYwYzI0LTQ4MCAyNjAtOTIwIDM3My0xMTMwIDI0LTUwIDQzLTgwIDUyLTEwMCAzMy04MC0xMDgtMjAwLTE2NS0yNDBhMTE0IDExNCAwIDAwLTUwIDEzMCAyNTYzIDI1NjMgMCAwMC0zNzAgODYwQTI3OTMgMjc5MyAwIDAwIDAgMzM2MGMtNiAzNDcgNTAgNjk0IDE3MCAxMDIyWm0yNjYwLTIzMTdhOTUgOTUgMCAxMCAwIDE5MCA5NSA5NSAwIDAwIDAtMTkwWm0tNTc2IDE1NjRhOTIgOTIgMCAxMCAwLTE4MyA5MiA5MiAwIDAwIDAgMTgzWiIgZmlsbD0iI0EzOTE2MSIvPjxwYXRoIGQ9Ik0zMDUxIDE4NDJhMzc0IDM3NCAwIDAwLTUwLTM0MGMtMzAtMzgtNjYtNzAtMTA4LTkzLTE4My0xMjUtNDA2LTQwLTQxMy0zOGE0NTYgNDU2IDAgMDEtMzcwIDc1Yy0zNDAtODgtNjEwLTUyNi02NjAtNjEzbC0yOC0zM2E1NSA1NSAwIDAwLTMwLTE4bC02Ny00M2E0NiA0NiAwIDAwLTUzIDFsLTcgNWgtMmMtNDItNC04NSA4LTExOSAzMy00MyAzMC04NSA3NC04MCAxMThsLTg2IDY0Yy0zNSAzLTY5IDE1LTk3IDM2LTI0IDIyLTYwIDU4LTY4IDk2bC01NyA0Mi0xMCA4djVhNDMgNDMgMCAwMC03IDE1IDIzIDIzIDAgMDAtMiAxMHYxNWw1IDRjNiAxMyA0OCA5NyA3NiAxNTAtODkgODAtMTcwIDE3MC0yNDYgMjYzIDcyIDU3IDIxMSAxODYgMTYwIDMwNy0xMCAyNi0zMCA2MS01NiAxMDgtMTEwIDIwNi0zNDAgNjM2LTM2NCAxMDk2YTMzNDAgMzM0MCAwIDAwIDkxIDk0MGMxMiA0NiAyMSA5NCAyOCAxNDIgMjAgMjMzLTEwMiAzMDYtMTkzIDM0NEEyMDcwIDIwNzAgMCAwMCA1MDAgNDk3N2M4MCA5MCAxODYgMjU5IDE2NSAzNjAtMjQtMTAtNTAtMTAtNzgtNi01MCAxMS05MiA0Ny0xMTMgOTQtMzAgNjctMTggMTQ2IDMyIDIwMCA0NSA0MyAxMTIgNTMgMTkzIDI2bDIgNWMxMCAxNiAyNSAyNyA0MiAzMGg0MGMxNDYgMCAzNzctODcgNjU2LTQ5NyA5OCAxOCAxODIgMzAgMjUwIDQwbDExMCAxOGM0MyAxNiAxNDMgMTAgMjAwLTEyMGwxMTEwLTI4ODBjNjAtMTMwIDQwLTI4Ny01Ni0zOThaTTE0MzAgMTAyMGMxIDMgMjQzIDQxOCA3MDYgNTEzIDMwIDYgNjAgMTAgOTIgMTAgOTcgMCAxNzAtMzUgMjQwLTcwYTQ3MCA0NzAgMCAwMSAyMDYtNjBjMjEgMCA0MyAyIDY0IDcgMjI4IDUwIDI0NCAyODggMjQ0IDI5MGEzMyAzMyAwIDAxLTMyIDM2aC0yYTM0IDM0IDAgMDEtMzMtMzFjMC04LTE0LTE5MC0xOTItMjMwYTIyNyAyMjcgMCAwMC00OS01Yy02MCAwLTExNCAyNS0xNzYgNTUtNzQgMzUtMTU4IDc0LTI3MCA3NC0zNiAwLTcwLTQtMTA2LTEwLTQ5NC0xMDItNzQ5LTU0Mi03NTAtNTQ3YTM0IDM0IDAgMDEgNTgtMzNabTg0NiAxMDQwdi0xNzdsNDUtMTQgMzktMTV2NjNsLTg0IDE0MlptMSA0djI5NWwtODcgMTYwdi0zMDhsODctMTQ3Wm0tMzEyIDUxOS0xMzQgMjI0djQ5N2wtODcgMTYwdi01MTBsODctMTQ3di04OTBsMTcgNCA2NCA2IDUzIDJoMXY2NTFsODctMTQ3di01MDdsMzUtM2MyMC0yIDM4LTUgNTYtMTBsNDUtN3YzMDBsLTEzNiAyMjh2NDEwbC04NyAxNjBWMjU4MHYzWm0tNTgwIDk3NHYtMTc5MGw0OCAzMCA1MyAyNiAzNSAxNXYxNDkwbDk4LTE0OVYxODYwYzIwIDggNDAgMTMgNjIgMTlsNTQgMTAgMTggM1YyOTUwbC0xMzQgMjI4djU4M2wtODcgMTYwVjMzMzBsLTEzNiAyMjhabS0yMjIgMzc0di0yMTEwbDM1LTM1IDkyLTkyIDggNXYxOTk0bC0xMDQgMTc2LTMwIDUyWm00IDF2Njg0bC04NyAxNjFWNDA4MGw4Ny0xNDhabTEzMS0yMjIgODctMTQ4djY4NWwtODcgMTYwVjM3MTBaTTkwMyAxMjI1bDQ0Ni00MDBhMzQgMzQgMCAwMSA0NSA1MGwtNDI3IDM4M2M1MCA5MyAxMjIgMTc0IDIxMCAyMzNhMzQgMzQgMCAwMS0zNSA1NyA3MTIgNzEyIDAgMDEtMjQ3LTI4NSAzNCAzNCAwIDAxIDgtMzhabTExIDI3NGExNzAgMTcwIDAgMTEgMCAzMzkgMTcwIDE3MCAwIDAxIDAtMzM5Wm0xNjAgNDE1VjQwODBMODgwIDQ0MDVBMjU1MiAyNTUyIDAgMDEgNjAwIDMzNjVhMjA5NyAyMDk3IDAgMDEgNDc0LTE0NTBaTTU4OCA0NzQ1YTE4MCAxODAgMCAxMSAzNjAgMCAxODAgMTgwIDAgMDEtMzYwIDBabTU0MCAyNTdMODMwIDU1ODlhMzMgMzMgMCAwMS02MC0zMGwyOTctNTg3YTMzIDMzIDAgMTEgNjAgMzBabTI2NCAyN2EzOCAzOCAwIDAxLTYyIDEwYy0zIDAtNTctNjAtMjE4LTE5MGEzOCAzOCAwIDExIDQ4LTYwIDY0NzAgNjQ3MCAwIDAxIDE4MCAxNTAgMzQ5NzgwIDM0OTc4MCAwIDAwIDExNTYtMjg4MGM1MC0xNDIgMTIwLTIwMCAxNjgtMjI0IDQwLTIwIDg4LTIzIDEzMC0xMGEzOCAzOCAwIDExLTI1IDczIDkzIDkzIDAgMDAtNzIgMmMtNTAgMjUtOTcgOTAtMTMwIDE4MC02MyAxODItMTEzMiAyODI2LTExNzcgMjk0MFptMTI4Ni0yNjUwYTUwIDUwIDAgMTEgMCAxMDAgNTAgNTAgMCAwMSAwLTEwMFptLTEzMiAzNjFjMCAxNy0xNSAzMi0zNCAzM2EzNCAzNCAwIDAxLTMzLTM0bC0xMC0zMDBhMzQgMzQgMCAxMSA2NSAwbDQgMzAwWm0tMTI3IDQ1Wm0tMzAzIDk5OGE1MCA1MCAwIDExLTUwIDUwYzAtMjggMjItNTAgNTAtNTBabS01MDkgOTM2YTM0IDM0IDAgMTEtNTItNDJsMjg1LTM1N2EzMyAzMyAwIDAxIDI2LTEzIDMzIDMzIDAgMDEgMjYgNTRsLTI4NSAzNjBabTIwMSAyNWE1MCA1MCAwIDExLTEwMCAwIDUwIDUwIDAgMDEgMTAwIDBabS02OS01NDBhNTAgNTAgMCAxMSA1MCA1MCA1MCA1MCAwIDAxLTUwLTUwWm0tNjAgODM4YTUwIDUwIDAgMTEgMC0xMDAgNTAgNTAgMCAwMSAwIDEwMFptMjE1IDY3YTI4IDI4IDAgMTEtNTQtMTUgMTc2IDE3NiAwIDEwLTM0Ni02NyAyOCAyOCAwIDAxLTU1LTd2LTJhMjMzIDIzMyAwIDExIDQ1NiA5MlptNDItMTI5NGMxOSAwIDM0IDEzIDM0IDMybDQgMzA1YzAgMTgtMTUgMzMtMzMgMzNhMzQgMzQgMCAwMS0zNC0zM2wtNC0zMDVjMC0xOCAxNS0zMyAzMy0zM1ptLTMyIDQ1NWE1MCA1MCAwIDExIDEwMCAxIDUwIDUwIDAgMDEtMTAwIDBabTkyIDY2MWMwIDIwLTE1IDM0LTMzIDM0YTM0IDM0IDAgMDEtMzQtMzVsMTEtNTQzYzAtMTggMTYtMzIgMzQtMzIgMTggMCAzMyAxNSAzMyAzNGwtMTAgNTQzWm0xMjAtNTQ4YTUwIDUwIDAgMTEgMC05OSA1MCA1MCAwIDAxIDAgMTAwWm0yNzMtNTI0LTM0MiAzNTJhMzMgMzMgMCAxMS00OC00OGwzNDItMzUzYTM0IDM0IDAgMDEgNTAgNDdaTTIyNTUgMzcwMGExNjggMTY4IDAgMTEgMC0zMzYgMTY4IDE2OCAwIDAxIDAgMzM3Wm0xMjQtNDIxYTUwIDUwIDAgMTEgMC0xMDAgNTAgNTAgMCAwMSAwIDEwMFptODUtMzMwLTI1MyAzMjBhMzQgMzQgMCAwMS01My00M2wyNTQtMzIwYTMzIDMzIDAgMDEgMjYtMTIgMzMgMzMgMCAwMSAyNiA1NlptOC0xMDBhNTAgNTAgMCAxMSA1MiA1MCA1MCA1MCAwIDAxLTUwLTUwWm0xMDAgNjMyYTM1IDM1IDAgMDEtMzMgMzMgMzQgMzQgMCAwMS0zNC0zNGwxMC00OTIgMS03di0zYzAtMTAgOC0xNyAxNy0yMGwxNi0yYzE4IDAgMzMgMTUgMzMgMzNsLTEwIDQ5NFptMTAwLTUyMmE1MCA1MCAwIDExIDAtMTAwIDUwIDUwIDAgMDEgMCAxMDBabTI5Mi01MDAtMzQ0IDM2MGEzMyAzMyAwIDAxLTQ3IDAgMzMgMzMgMCAwMS0xMC0zNCAyMCAyMCAwIDAxIDYtMTVsMzQzLTM1MmExOSAxOSAwIDAxIDEwLTUgMzMgMzMgMCAwMSA0MCA1M1ptLTEzMC0xMzRhMTcxIDE3MSAwIDExIDE3MC0xNzBjMCA5My03NSAxNzAtMTcwIDE3MFoiIGZpbGw9IiNBMzkxNjEiLz48cGF0aCBkPSJNNDM3MCAwYTE2ODc3MiAxNjg3NzIgMCAwMCAwIDY0MDBoNTFhMTY4NzczIDE2ODc3MyAwIDAwIDAtNjQwMGgtNTFabTIxNDAgMzExNWMtODYgMC0xOTItNDMtMjUyLTEwMS04MS04MC0xMDEtMTEyLTIwNS0zNDBsLTQ1IDNjLTEwIDAtMjItMS00MC00djE4M2MwIDEwNSAyMCAxMzAgMTIwIDE0OHYzMGgtNDM3di0zMGMxMTQtMTMgMTQwLTQwIDE0MC0xNDhWMjM2MGMwLTEwNC0yMy0xMzgtMTIwLTE3MXYtMjlsMjcwIDE1YTkwMCA5MDAgMCAwMSAxNzYtMTljMTU2IDAgMjUwIDg1IDI1MCAyMjYgMCA0MC03IDc2LTIyIDEwNS0yNCA1MC01NyA4My0xNDMgMTQ0IDEzNSAyMTcgMjAwIDMxMCAyNjMgMzY4IDQ1IDQyIDk2IDY1IDE2NSA3NXYyM2EzOTAgMzkwIDAgMDEtMTEwIDE3Wm0tNTQyLTg5N3YzNzdhMjE2IDIxNiAwIDAwIDE1MCAxMGwyNC0zMGMzMC00MiA0Ny05MiA0Ny0xNDkgMC0xMjYtNzAtMTkyLTIyMS0yMDhaIiBmaWxsPSIjZmZmIi8+PHBhdGggZD0iTTY1NTcgMzAzM3YtMjljMTgtNSAzMS0xMCA0Mi0xNyAyNC0xOCAzMC0zNCAzMi0xMjJsMTAtMjYwdi0xMGEzMDAgMzAwIDAgMDAtMTAtODhjMC0yMS0yMC0zMC01MC00M3YtMjdsMTkwLTM4IDQ3IDgtMTAgMTY4djI4MGMtMSAxMDcgNyAxMjIgNjUgMTQwdjI5aC0zMTBabTE2OC03NjVjLTYzIDAtMTEzLTQ1LTExMy0xMDEgMC01MiA1MC05NCAxMTMtOTQgNjAgMCAxMTAgNDIgMTEwIDk0IDAgNTYtNTAgMTAwLTExMCAxMDBabTYxOCA3NzhoLTJjLTQ2IDAtNzAtMTYtOTAtNjAtNjIgNTItOTggNjYtMTYwIDY2LTk0IDAtMTU2LTU2LTE1Ni0xMzggMC0zMSA4LTYwIDIzLTgzIDE4LTI4IDQ1LTQ0IDExNi02OWwxODctNjV2LTgzbC0zLTc1YzAtNTItMTAtNjYtNTAtNjYtNDYgMC03MyAyMy0xMDAgODdsLTM0IDcxaC0zOGMtNDYgMC03NC0xOS03NC01MiAwLTMwIDI0LTY3IDY1LTk2IDcwLTUzIDE1NS04MCAyNTItODAgMTAwIDAgMTM4IDM2IDEzOCAxMjh2MTdsLTEwIDI5NHYxMGMwIDc0IDE3IDk4IDk0IDEzNXYzNmMtNTkgMTQtMTA5IDIzLTE1MCAyM1ptLTkxLTI4OC05NCA0MmMtNTQgMjUtNzUgNTAtNzUgOTAgMCA0NCAzMiA3MiA4MCA3MiAyNCAwIDU0LTQgOTAtMTN2LTIwMFptMjg0IDI3NXYtMjljNTgtMTIgNzAtMzUgNzQtMTM5bDEwLTI2MHYtMjUyYzAtMTEwLTMtMTM1LTE0LTE3Mi03LTI0LTE1LTM1LTQzLTUyVjIxMDBsMjAwLTM2IDMzIDI3YTE2NzAgMTY3MCAwIDAwLTE5IDMzMHY0NDRjMCAxMDcgMTggMTMwIDcyIDE0MHYyOGgtMzEzWm02MDAgMjBjLTExMCAwLTE3My01Ny0xNzAtMTU5bDEwLTM0Ni02Ni04NHYtMzdjNTUtMjAgNzYtMzMgMTE1LTczIDI1LTI0IDM2LTM3IDYyLTc3bDY1IDMwLTIwIDEyNCAxMTMtMTBjMzQgOSA1NSAyOSA1NSA1OSAwIDM0LTMwIDYwLTc0IDYwaC05M3YzMTZjMCA1NyAxMCA4MyAzNSAxMDAgMjQgMTYgNTEgMjIgMTIzIDIybDEwIDI4Yy02MCA0NC05NCA1Ny0xNTQgNTdabTYyMi03aC0yYy00NiAwLTcwLTE2LTkwLTYwLTczIDUyLTExMCA2Ni0xNzAgNjYtOTQgMC0xNTctNTYtMTU3LTEzOCAwLTMwIDEwLTYwIDIzLTgzIDIwLTI4IDQ2LTQ0IDExOC02OWwxODYtNjV2LTgzbC0yLTc1Yy0yLTUyLTEwLTY2LTUwLTY2LTQ2IDAtNzMgMjMtMTAyIDg3bC0zMiA3MWgtMzhjLTQ2IDAtNzQtMTktNzQtNTIgMC0zMCAyNC02NyA2NS05NiA3MS01MyAxNTctODAgMjU0LTgwIDk4IDAgMTM4IDM2IDEzOCAxMjh2MTdsLTEwIDI5NHYxMGMwIDc0IDE2IDk4IDkzIDEzNXYzNmE2NzAgNjcwIDAgMDEtMTUwIDIzWm0tOTItMjg4LTkzIDQyYy01NCAyNS03NSA1MC03NSA5MCAwIDQ0IDMyIDcyIDgwIDcyIDI0IDAgNTMtNCA4OC0xM3YtMjAwWm01NjAgMjg4Yy01NyAwLTk3LTQtMjI2LTI3bC0xOS0xODIgMzctMTBjNjUgODAgOTIgMTA3IDEyNyAxMzMgMjAgMTYgNTMgMjggNzMgMjggNDMgMCA3Ny0zNSA3Ny03OGE3MCA3MCAwIDAwLTgtMzQgNjYgNjYgMCAwMC0yNi0yOGwtNTYtMzAtNzUtMzdjLTExMC01NC0xNTItMTA4LTE1Mi0xOTAgMC0xMTQgODctMTg4IDIyMi0xODggNjEgMCA5NiA3IDE4MiAzNGwxOCAxNDAtMzcgMThhNTIwIDUyMCAwIDAwLTEwMi0xMDcgMTMwIDEzMCAwIDAwLTcwLTI1IDc2IDc2IDAgMDAtODAgNzVjMCAzOCAyNSA2NCA4NCA5M2wxMTIgNTdjOTYgNDkgMTMxIDkyIDEzMSAxNjYgMCAxMTYtODUgMTkyLTIxMyAxOTJabTk0Ny0xM3YtMjljNjAtMTIgNzItMzQgNzYtMTM5di0yNDBjMC04My00MC0xMjYtMTE1LTEyNi0zMCAwLTUzIDctMTAwIDMxdjMzNWMwIDEwNyA4IDEyNyA1NSAxNDB2MjhIOTgwMHYtMjljNTgtMTIgNzAtMzUgNzQtMTM5bDEwLTI2MHYtMTNjMC03OC0xNS0xMDQtNzYtMTI4di0yN2wyMzQtMzh2ODBjODYtNzAgMTI4LTgwIDIxMy04MCAxMTAgMCAxNjAgNTAgMTYwIDE2MHYyOTdjMCA5NyAxMCAxMjIgNjQgMTQwdjMwaC0zMDhabTc4OCAxM2gtMmMtNDYgMC03MC0xNi05MC02MC03MiA1Mi0xMDkgNjYtMTcwIDY2LTk0IDAtMTU2LTU2LTE1Ni0xMzggMC0zMCA4LTYwIDIzLTgzIDIwLTI4IDQ1LTQ0IDExNy02OWwxODYtNjV2LTgzbC0yLTc1Yy0yLTUyLTEwLTY2LTUwLTY2LTQ2IDAtNzMgMjMtMTAwIDg3bC0zNCA3MWgtMzhjLTQ2IDAtNzQtMTktNzQtNTIgMC0zMCAyNC02NyA2NS05NiA3Mi01MyAxNTctODAgMjU0LTgwIDEwMCAwIDEzOCAzNiAxMzggMTI4djE3bC0xMCAyOTR2MTBjMCA3NCAxNiA5OCA5MyAxMzV2MzZhNjcwIDY3MCAwIDAxLTE1MCAyM1ptLTkyLTI4OC05MyA0MmMtNTQgMjUtNzUgNTAtNzUgOTAgMCA0NCAzMiA3MiA4MCA3MiAyNCAwIDUzLTQgODgtMTN2LTIwMFptOTM3IDI3NXYtMjljNTgtMjAgNzAtNDIgNzQtMTM5bDEwLTIyNGMwLTkzLTMxLTEyOS0xMDctMTI5LTMyIDAtNTUgNi0xMDggMjh2MzM1YzAgOTYgMTAgMTIyIDU2IDE0MHYyOGgtMjk4di0yOWM2NC0xMyA3MC0yNyA3NS0xMzlsMTAtMjYwdi0zNTBjLTEtNzgtMTctMTAzLTc1LTEyNnYtMzBsMjEzLTM2IDM4IDM2LTIwIDM4M2M5MC02NSAxMzgtODQgMjEwLTg0IDUwIDAgOTAgMTQgMTIwIDM4IDMwIDI1IDQ0IDYwIDQ0IDEzMnYyOThjMCAxMDggNyAxMjQgNjUgMTQwdjI4aC0zMDdabTk4MCAwaC02NDV2LTI5YzExMy0xNSAxNDAtNDMgMTQwLTE0OFYyMzYwYzAtMTEyLTE3LTE0MC0xMDItMTY3di0yN2g1ODdsMjAgMjA0LTMwIDEwYy02MC0xMDgtMTA0LTE0MS0xOTYtMTUwbC0xMDItMTB2MzM3bDkzLTRjOTYtNCAxMTYtMjAgMTQwLTEwN2gzMHYyNzloLTMwYy0yNy04My01Mi0xMDMtMTQwLTEwN2wtODItNHYyMjNjMCA5OSAyNyAxMzEgMTEzIDEzMSAxMDAgMCAxNjAtNDUgMjQwLTE3N2wyOCAxOC01NSAyMjRabS0xNDctOTc4LTI2MCA0NS0xMC0xNyAyMzAtMTQwIDYwIDQ3LTI5IDY1Wm0yNzcgOTc4di0yOWMxOC01IDMxLTEwIDQyLTE3IDI0LTE4IDMwLTM0IDMyLTEyMmwxMC0yNjB2LTEwYzAtMzQtNi02OS0xMi04OC0xMC0yMC0yMi0zMC01NC00M3YtMjdsMTg2LTM4IDQ3IDEwLTEwIDE2NnYyODBjMCAxMDcgOCAxMjIgNjYgMTQwdjMwaC0zMDdabTE2OC03NjVjLTYzIDAtMTEzLTQ1LTExMy0xMDAgMC01MyA1MC05NSAxMTMtOTUgNjAgMCAxMTAgNDIgMTEwIDk0IDAgNTYtNTAgMTAwLTExMCAxMDBabTYyNCAzNTVjLTQyLTM0LTgzLTUyLTExNC01Mi0yMCAwLTQwIDE0LTYzIDQ3djI0N2MwIDk2IDIwIDEyMCAxMjEgMTQwdjI4aC0zNjN2LTI5YzYwLTIwIDcwLTQwIDcwLTEzOWwxMC0yODB2LTZjMC03MC0yMC0xMDAtODAtMTIwdi0zMGwyMzItNDAtNiAxNDBoNmM1NC05OSA5Ny0xNDAgMTUwLTE0MCA0MSAwIDcwIDQwIDcwIDk3IDAgNDQtOCA3MC00MyAxMjdabTU5MyA3NWgtMzU0djE0YzAgNjAgMiA3MCAxMCAxMDYgMjAgODIgODYgMTMwIDE4OCAxMzAgNTAgMCA4MC02IDE0Ny0zNmwyMCAxMGMtOCAyMC0xNCAzNi0xOSA0MmEzNDAgMzQwIDAgMDEtMjQ2IDkzYy0xNTAgMC0yNTctMTI4LTI1Ny0zMDUgMC0yMDYgMTIyLTM1NCAyOTUtMzU0IDEzOCAwIDIyOCA3NSAyMjggMTkxIDAgMjgtNCA2NC0xMiAxMTBabS0xNTItMTkwYTc3IDc3IDAgMDAtNzMtNDRjLTM1IDAtNjggMTYtOTIgNDctMjIgMzAtMzAgNTMtMzcgMTEyaDE5NmwxOC0xOWMwLTU4LTMtNzQtMTItOTdabTY0MyA1MzhoLTNjLTQ2IDAtNzAtMTYtOTAtNjAtNzIgNTItMTA5IDY2LTE3MCA2Ni0xMDAgMC0xNjAtNTYtMTYwLTEzOCAwLTMwIDItNjAgMjAtODMgMjAtMjggNDMtNDQgMTE0LTY5bDE4OC02NXYtODNsLTMtNzVjMC01Mi0xMC02Ni01MC02Ni00NiAwLTczIDIzLTEwMCA4N2wtMzQgNzFoLTM1Yy00NiAwLTc1LTE5LTc1LTUyIDAtMzAgMjUtNjcgNjUtOTYgNzItNTMgMTU3LTgwIDI1NC04MCAxMDAgMCAxMzggMzYgMTM4IDEyOHYxN2wtMTAgMjk0djEwYzAgNzQgMTcgOTggOTQgMTM1djM2YTY3MCA2NzAgMCAwMS0xNTAgMjNabS05Mi0yODgtOTMgNDJjLTU0IDI1LTc2IDUwLTc2IDkwIDAgNDQgMzIgNzIgODEgNzIgMjMgMCA1My00IDg4LTEzdi0yMDBabTY2NSAyNzV2LTI5YzYwLTEyIDcyLTM0IDc2LTEzOWwxMC0yMzR2LTZjMC04My00MC0xMjYtMTE2LTEyNi0zMCAwLTUzIDctMTAwIDMxdjMzNWMwIDEwNyA4IDEyNyA1NiAxNDB2MjhoLTI5OHYtMjljNTgtMTIgNzAtMzUgNzUtMTM5bDEwLTI2MHYtMTNjMC03OC0xNi0xMDQtNzctMTI4di0yN2wyMzQtMzh2ODBjODctNzAgMTMwLTgwIDIxNC04MCAxMTAgMCAxNjAgNTAgMTYwIDE2MHYyOTdjMCA5NyAxMCAxMjIgNjQgMTQwdjMwaC0zMDhabTc0NiAwdi0yOWM2MC0xMiA3Mi0zNCA3Ni0xMzlsMTAtMjM0di02YzAtODMtNDAtMTI2LTExNi0xMjYtMzAgMC01MiA3LTEwMCAzMXYzMzVjMCAxMDcgOCAxMjcgNTYgMTQwdjI4aC0yOTd2LTI5YzU3LTEyIDcwLTM1IDc0LTEzOWwxMC0yNjB2LTEzYzAtNzgtMTYtMTA0LTc2LTEyOHYtMjdsMjMzLTM4djgwYzg3LTcwIDEzMC04MCAyMTQtODAgMTEwIDAgMTYwIDUwIDE2MCAxNjB2Mjk3YzAgOTcgMTAgMTIyIDY0IDE0MHYzMGgtMzA4Wm0tOTY1MCAxMTM1djk0bDIxIDEzMGgtNDNjLTE2IDAtMjMgMC0xMjUgMzMtNTAgMTUtMTEwIDIzLTE3OSAyMy0xMzggMC0yMTktMjgtMjk3LTEwMmE0NjQgNDY0IDAgMDEtMTQwLTM0MmMwLTEyNyA0NC0yNDggMTIxLTMzMGE0MjAgNDIwIDAgMDEgMzMyLTEzMGM5MCAwIDE1MCAxMCAyODMgNTZsMTAgMjA1LTI4IDE5QzYzMzAgMzY1NCA2MjYwIDM2MDAgNjEyNyAzNjAwYy0xNzMgMC0yOTAgMTU4LTI5MCAzOTBzMTMzIDM5MyAzMjQgMzkzYzEyNSAwIDE5MC01MSAxOTAtMTUwdi01NWMwLTk2LTI3LTEyNC0xMzAtMTQ1VjQwMDBoMzQ0djI3Yy04NCAyNy0xMDMgNTMtMTAzIDE0MFptNDc2IDI4MGMtMTY2IDAtMjYwLTEwNy0yNjAtMjk0IDAtMjI1IDEyNS0zNjMgMzI2LTM2MyAxNjYgMCAyNjAgMTA2IDI2MCAyOTUgMCAyMjQtMTI0IDM2Mi0zMjYgMzYyWm0zMC02MDBjLTEwMCAwLTE3MCAxMDctMTcwIDI2MCAwIDE2NiA3NCAyODUgMTc2IDI4NSAxMDAgMCAxNzAtMTEwIDE3MC0yNjUgMC0xNjQtNzQtMjgwLTE3Ny0yODBabTg5MyAzYy0xNSAxMC0zNCA0MC00NiA2NmwtMjA1IDQ3NGMtMjAgNDQtMzggNjctNTcgNjdoLTRsLTE3My01NDBjLTEyLTM5LTMwLTYyLTY1LTc1di0yOWgyNDJ2MzBsLTI3IDdjLTMwIDEwLTQyIDIzLTQyIDQ4IDAgMTQgNCAzNiAxNCA2NEw3NjAwIDQyODFsMTEyLTMwMGMxMi0zMSAxOC02MCAxOC04MCAwLTMzLTI3LTUwLTg0LTU0di0zM2gyMzR2MzBsLTIwIDdabTMwMyA1OTNjLTE0MCAwLTIzOC0xMjMtMjM4LTMwMCAwLTIxMyAxMTYtMzQ0IDMwMS0zNDQgMTIzIDAgMTkzIDYyIDE5MyAxNjggMCAyOC0xMCA2My0xMCAxMDJoLTM5MHYzNWMwIDE1MyA3MyAyNDMgMjAwIDI0MyA1MCAwIDgwLTggMTcwLTQwbDI0IDVjLTE3IDY4LTE0MyAxMzEtMjYwIDEzMVptMTU0LTQ4MGMwLTU4LTUwLTEwNC0xMTUtMTA0LTc2IDAtMTM0IDU0LTE2NSAxNTRoMjYwbDIwLTIzdi0yOFptNTkzLTIwLTEwIDE2YTIyMyAyMjMgMCAwMC05OC0yOGMtMzcgMC02NiAyNy05OSA4NXYyMzVjMCAxMDcgMzAgMTM1IDE1MCAxNDV2MzJoLTM0NnYtMzJjNjgtMTggODEtNDAgODUtMTQ1bDgtMjI0YzItOCAyLTE2IDItMjQgMC05Mi0xMC0xMTItNzYtMTQ0di0yN2wxNzctMzd2MTUzYzk3LTEyNSAxMjctMTQ3IDE5Ny0xNDcgMjUgMCA0NCAyMCA0NCA0MyAwIDMwLTEyIDYzLTM0IDk4Wm00NDQgNDg1di0zMmM3NC0xMiA5MC0zNCA5My0xNDVsMTAtMjI0di04YzAtODQtNDMtMTM1LTExMi0xMzUtNDYgMC03OCAxMC0xNjAgNTB2MzE3YzAgNDkgNSA4MyAxMCA5OCAxMCAyNCAzNiAzNyA4NCA0N3YzMmgtMjkwdi0zMmM3MC0xOCA4Mi0zOCA4Ni0xNDVsOC0yMjRjMi02IDItMTIgMi0yMCAwLTkwLTE3LTEyMS03Ni0xNDh2LTI3bDE2My00MSAxNCA4djkzYzExOC03NCAxNzItOTcgMjM2LTk3IDM2IDAgODAgMTYgMTAwIDM3IDI1IDI1IDM3IDY4IDM3IDEzMHYyOTBjMCAxMDkgOCAxMjAgODQgMTQ0djMyaC0yOTBabTExMTAgMHYtMzJjNzMtMTIgOTAtMzQgOTItMTQ1bDEwLTIyNHYtMTBjMC04Mi00Mi0xMzUtMTA3LTEzNS00NSAwLTc2IDE0LTE2NCA2NnYzMDNjMCA0OSA0IDgzIDEwIDk3IDEwIDI1IDM1IDM4IDg0IDQ4djMyaC0yOTl2LTMyYzc2LTEyIDkwLTM0IDkzLTE0NWwxMC0yMjR2LTEwYzAtODItNDAtMTM1LTEwNy0xMzUtNDAgMC02MCA3LTE2NCA1MnYzMTdjMCA0OSA0IDgyIDEwIDk3IDEwIDI1IDM1IDM4IDg0IDQ4djMyaC0yOTB2LTMyYzcwLTE4IDgyLTM4IDg2LTE0NWw4LTIyNCAxLTI1YzAtOTEtMTAtMTEyLTc2LTE0M3YtMjdsMTY4LTM4IDEwIDEwdjg4YzExNi03NSAxNzItOTggMjQzLTk4IDcxIDAgOTggMjUgMTMwIDExMiAxMDUtODYgMTYwLTExMiAyMzctMTEyIDQzIDAgODMgMjAgMTA3IDQ4IDIwIDI0IDI4IDYwIDI4IDEyMHYyOTBjMCAxMDggOCAxMjIgODQgMTQ0djMyaC0yOTBabTYyMCAxNWMtMTQwIDAtMjM4LTEyMy0yMzgtMzAwIDAtMjEzIDExNi0zNDQgMzAxLTM0NCAxMjMgMCAxOTMgNjIgMTkzIDE2OCAwIDI4LTMgNjMtMTAgMTAyaC0zODJ2MzVjMCAxNTMgNzUgMjQzIDIwMCAyNDMgNTAgMCA4MS04IDE3MC00MGwyNiA1Yy0xNiA2OC0xNDIgMTMxLTI2MCAxMzFabTE1My00ODBjMC01OC01MC0xMDQtMTE1LTEwNC03NSAwLTEzMyA1NC0xNjQgMTU0aDI2MGwyMC0yM3YtMjhabTU1NSA0NjV2LTMyYzc0LTEyIDkwLTM0IDkzLTE0NWwxMC0yMjR2LThjMC04NC00Mi0xMzUtMTEwLTEzNS00NyAwLTgwIDEwLTE2MCA1MHYzMTdjMCA0OSAzIDgzIDEwIDk4IDEwIDI0IDM0IDM3IDgyIDQ3djMyaC0yODl2LTMyYzcwLTE4IDgxLTM4IDg1LTE0NWwxMC0yMjR2LTIwYzAtOTAtMTYtMTIxLTc2LTE0OHYtMjdsMTY0LTQxIDEzIDh2OTNjMTE4LTc0IDE3Mi05NyAyMzctOTcgMzUgMCA3OCAxNiAxMDAgMzcgMjQgMjUgMzYgNjggMzYgMTMwdjI5MGMwIDEwOSA4IDEyMCA4NCAxNDR2MzJoLTI5MFptNTgwIDE0Yy0xMDUgMC0xNTAtNDItMTQ2LTE1Mmw4LTM2OC02NC03MiA0LTM2YTI5MCAyOTAgMCAwMCAxMzgtMTQwbDM2IDE0LTEwIDE0MCAxNjctMTBjMjUtMiAzOCAxMiAzOCAzMyAwIDMwLTI3IDUwLTY1IDUwaC0xNDB2MzMwYzAgOTAgMzAgMTQwIDg3IDE0MCAzMSAwIDcyLTEwIDExOC0zMmwxMCAyOWMtNjcgNjItOTggNzQtMTgwIDc0Wm03NDggNWMtMTY2IDAtMjYwLTEwNy0yNjAtMjk0IDAtMjI1IDEyNS0zNjIgMzI3LTM2MiAxNjYgMCAyNjAgMTA1IDI2MCAyOTQgMCAyMjQtMTI0IDM2Mi0zMjcgMzYyWm0zMC02MDBjLTk5IDAtMTY5IDEwNy0xNjkgMjYwIDAgMTY2IDczIDI4NSAxNzYgMjg1IDEwMCAwIDE3MC0xMTAgMTcwLTI2NSAwLTE2My03NC0yODAtMTc3LTI4MFptOTA0LTI1NGMtNjAtNTgtMTAwLTc4LTE1MC03OC01NCAwLTkwIDI2LTEyMCA4NC0yMyA0Mi0yOCA3Ny0zNSAxNzBsLTQgNTggMTY4LTEwYzI0IDAgMzcgMTQgMzcgMzYgMCAzNi0xMCA0NC01NSA0NGgtMTUwbDEwIDM1NGMwIDQyIDMgNzAgMTAgODQgMTEgMzIgNTAgNTEgMTIxIDYwdjMzaC0zMzd2LTMyYzc0LTEyIDkzLTQzIDkzLTE0NXYtMzIwbC04My02MnYtMjBsOTAtNTZjOC0xMzYgMjgtMTkzIDkyLTI1NiA1MC01MiAxMjMtODAgMjEwLTgwIDExMiAwIDE3NiAyNCAxNzYgNjMgMCAzNS0yMyA1Ny03MyA3M1ptMTg3IDgzNXYtMjhjMTA4LTE2IDEzMC00MiAxMzAtMTQ5VjM3NDBjMC0xMDQtMjAtMTMwLTEyMC0xNTB2LTI3aDM2M3YyN2MtMTA4IDE4LTEzMCA0My0xMzAgMTUwdjUxMmMwIDEwNyAyMiAxMzMgMTMwIDE0OXYyOGgtMzczWm04NTAtNDg2LTEyIDE3YTIyMCAyMjAgMCAwMC05Ny0yOGMtMzcgMC02NyAyNy0xMDAgODV2MjM1YzAgMTA3IDMwIDEzNSAxNTAgMTQ1djMyaC0zNDV2LTMyYzY3LTE4IDgxLTQwIDg1LTE0NWw4LTIyNCAxLTI0YzAtOTItMTAtMTEyLTc1LTE0NHYtMjdsMTc3LTM3djE1M2M5Ny0xMjUgMTI3LTE0NyAxOTctMTQ3IDI0IDAgNDMgMjAgNDMgNDNhMjAwIDIwMCAwIDAxLTMzIDk4Wm0zMjYgNTAxYy0xNDAgMC0yMzgtMTIzLTIzOC0zMDAgMC0yMTMgMTE2LTM0NCAzMDEtMzQ0IDEyMyAwIDE5MyA2MiAxOTMgMTY4IDAgMjgtMiA2My0xMCAxMDJoLTM4MHYzNWMwIDE1MyA3MyAyNDMgMjAwIDI0MyA1MCAwIDgwLTggMTY3LTQwbDI3IDVjLTE2IDY4LTE0MCAxMzEtMjYwIDEzMVptMTU0LTQ4MGMxMC01OC00MC0xMDQtMTA0LTEwNC03NiAwLTEzNCA1NC0xNjUgMTU0aDI2MGwyMS0yM3YtMjhabTE4OCA0NjV2LTMyYzczLTEyIDkwLTM1IDkyLTE0NWwxMC0yNjB2LTI2MGMwLTE0MC0xMC0xNzEtNjUtMTk2di00MGwxNjctMjYgMjEgMTgtMjAgMzQ1djQyMGMwIDQ4IDMgODIgMTAgOTcgMTAgMjQgMzQgMzcgODQgNDd2MzJoLTMwMFptODUwIDZjLTIwIDItNDAgNS01OCA1LTU1IDAtNzMtMTUtODktNjktODAgNTgtMTE5IDcyLTE5MCA3Mi05MCAwLTE0NS00OS0xNDUtMTI5IDAtNjcgMzctMTA1IDE0MC0xNDNsMjA0LTc2di0xMTNjMS04OC0yMC0xMTMtOTQtMTEzLTY4IDAtOTUgMjQtMTI5IDExM2wtMjAgNDZjLTUwLTctNzQtMjQtNzQtNTQgMC00NiA3NC0xMTIgMTY2LTE0NyA0MC0xNSAxMDAtMjcgMTM3LTI3IDg1IDAgMTIxIDM3IDEyMSAxMjR2MjZsLTEzIDMxNnYxMGMwIDY3IDIwIDg4IDExMCAxMjB2MzBsLTY3IDEwWm0tMjc1LTIzN2MtNjIgMjYtOTIgNTgtOTIgMTAwIDAgNDAgMzUgNzYgNzYgNzYgMjQgMCA2MC04IDEwMy0yNGw0MC0xNCAxMC0xOTUtMTM4IDU3Wm03NzAgMjMxdi0zMmM3NC0xMiA5MC0zNCA5My0xNDVsMTAtMjI0di04YzAtODQtNDMtMTM1LTExMC0xMzUtNDggMC04MCAxMC0xNjAgNTB2MzE3YzAgNTAgMyA4MyAxMCA5OCA4IDI0IDMzIDM3IDgyIDQ3djMyaC0yOTB2LTMyYzcwLTE4IDgyLTM4IDg2LTE0NWw3LTIyNCAxLTIwYzAtOTAtMTYtMTIxLTc1LTE0OHYtMjdsMTYzLTQxIDE0IDh2OTNjMTE4LTc0IDE3Mi05NyAyMzctOTcgMzUgMCA4MCAxNiAxMDAgMzcgMjUgMjUgMzcgNjggMzcgMTMwdjI5MGMwIDEwOSA4IDEyMCA4NCAxNDR2MzJoLTI5MFptODMwIDIwLTE5LTIwdi02NWMtNzAgNjAtMTI0IDg0LTE5MyA4NC0xMzkgMC0yMzUtMTIzLTIzNS0zMDAgMC0yMDAgMTMwLTM1MiAzMDAtMzUyIDQ0IDAgNzAgNSAxMzAgMjh2LTEwMGMxLTEzOS0yMC0xNzgtMTA5LTE5OXYtMzJsMjEwLTIzIDIxIDE3LTIwIDMyN3Y0MzhjMCA4NCAxNSAxMDYgODYgMTI2djMybC0xNzAgMzhabS0xOS00NDhjMC04Ny00OC0xNDUtMTIwLTE0NS0xMTAgMC0xOTggMTA3LTE5OCAyNDIgMCAxNTUgODIgMjYwIDIwNCAyNjAgNDIgMCA2My01IDExMy0zMnYtMzI1WiIgZmlsbD0iI2ZmZiIvPjwvZz48ZGVmcz48Y2xpcFBhdGggaWQ9ImEiPjxwYXRoIGQ9Ik0wIDBoMTgwOTN2NjQwMEgwIiBmaWxsPSIjZmZmIi8+PC9jbGlwUGF0aD48L2RlZnM+PC9zdmc+Cg=="
+        },
+        "language_info": {
+          "autoDetect": true,
+          "fallbackLanguage": "en"
+        },
+        "sign_in": {
+          "methods": []
+        },
+        "sign_up": {
+          "verify": false,
+          "password": false,
+          "identifiers": []
+        },
+        "social_sign_in_connector_targets": ["MyGovId (MyGovId connector)", "OGCIO EntraID"],
+        "sign_in_mode": "SignInAndRegister",
+        "agree_to_terms_policy": "Automatic",
+        "privacy_policy_url": "<SEEDER_PROFILE_PRIVACY_POLICY_URL>",
+        "terms_of_use_url": "<SEEDER_PROFILE_TERMS_OF_USE_URL>"
+      }
+    ],
+    "webhooks": [
+      {
+        "id": "login-webhook",
+        "name": "User log in",
+        "events": [
+          "User.Created",
+          "User.Deleted",
+          "User.Data.Updated",
+          "User.SuspensionStatus.Updated"
+        ],
+        "config": {
+          "url": "<SEEDER_WEBHOOK_LOGIN_URL>"
+        },
+        "signing_key": "<SEEDER_WEBHOOK_SIGNING_KEY>",
+        "enabled": true
+      }
+    ],
+    "raw_queries": [
+      {
+        "name": "Re-insert all",
+        "query": "begin; insert into public.scopes (tenant_id, id, resource_id, \"name\", description) values('default','management-api-all','management-api','all','Default scope for Management API, allows all permissions.') on conflict do nothing; insert into public.roles_scopes  (tenant_id, id, role_id, scope_id) values('default','70pjp17i4m4y01gm1jv3e','admin-role','management-api-all') on conflict do nothing; commit;"
+      }
+    ]
+  }
+}

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-uat.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-uat.json
@@ -7,6 +7,11 @@
         "id": "ogcio"
       },
       {
+        "name": "Nearform Testing Org",
+        "description": "Testing organization created through seeder",
+        "id": "nearform-testing"
+      },
+      {
         "name": "An Bord Pleanála",
         "description": "An Bord Pleanála",
         "id": "abp"
@@ -27,6 +32,11 @@
         "id": "second-testing"
       },
       {
+        "name": "Dept. of Education/An Roinn Oideachais",
+        "description": "Dept. of Education/An Roinn Oideachais - Imported from Digital Postbox",
+        "id": "doe"
+      },
+      {
         "name": "Health Service Executive",
         "description": "Health Service Executive - Imported from Digital Postbox",
         "id": "hse"
@@ -35,11 +45,6 @@
         "name": "Department of Social Protection",
         "description": "Department of Social Protection - Imported from Digital Postbox",
         "id": "dsp"
-      },
-      {
-        "name": "Dept. of Education/An Roinn Oideachais",
-        "description": "Dept. of Education/An Roinn Oideachais - Imported from Digital Postbox",
-        "id": "doe"
       },
       {
         "name": "Limerick City and County Council",
@@ -74,20 +79,20 @@
         "messaging:provider:*",
         "messaging:template:*",
         "messaging:event:read",
+        "o11y:dashboard:read",
+        "o11y:dashboard:write",
+        "o11y:dashboard:admin",
         "profile:user:read",
         "profile:user:write",
         "profile:user:*",
-        "profile:user.admin:*",
         "profile:user.self:read",
         "profile:user.self:write",
+        "profile:user.admin:*",
         "life-events:digital-wallet-flow:*",
         "bb:public-servant.inactive:*",
         "scheduler:jobs:write",
         "upload:file:*",
         "o11y:metrics:*",
-        "o11y:dashboard:read",
-        "o11y:dashboard:write",
-        "o11y:dashboard:admin",
         "journey:journey.public:read",
         "journey:journey:read",
         "journey:journey:*",
@@ -196,7 +201,7 @@
         "name": "File Upload Public Servant",
         "description": "File Upload Public servant",
         "specific_permissions": [
-          "upload:file:*", 
+          "upload:file:*",
           "profile:user:read",
           "profile:user.self:read",
           "profile:user.self:write"
@@ -286,12 +291,11 @@
         "specific_permissions": ["scheduler:jobs:write"],
         "type": "MachineToMachine",
         "related_applications": [
-          { "application_id": "f7p2k8w5jv4c1rm6xn3q9", "organization_id": "ogcio" },
-          { "application_id": "f7p2k8w5jv4c1rm6xn3q9", "organization_id": "abp" },
-          { "application_id": "f7p2k8w5jv4c1rm6xn3q9", "organization_id": "first-testing" },
-          { "application_id": "f7p2k8w5jv4c1rm6xn3q9", "organization_id": "second-testing" },
-          { "application_id": "f7p2k8w5jv4c1rm6xn3q9", "organization_id": "doe"}
-        ]
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "ogcio" },
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "abp" },
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "doe"},
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "second-testing" },
+          { "application_id": "d5q7l2m9r3w1x6bp8cv0j", "organization_id": "first-testing"}]
       },
       {
         "id": "m2m-analytics",
@@ -451,10 +455,10 @@
         ],
         "type": "MachineToMachine",
         "related_applications": [
-          { "application_id": "k3wblfnr6h8b8x8l8nigt", "organization_id": "ogcio" },
-          { "application_id": "k3wblfnr6h8b8x8l8nigt", "organization_id": "abp" },
-          { "application_id": "k3wblfnr6h8b8x8l8nigt", "organization_id": "first-testing" },
-          { "application_id": "k3wblfnr6h8b8x8l8nigt", "organization_id": "second-testing" },
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "ogcio" },
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "abp" },
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "first-testing" },
+          { "application_id": "03jn5vm2pfh3a0433p4fp", "organization_id": "second-testing" },
           { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "hse"},
           { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "dsp"},
           { "application_id": "r58qdwh2da6qtsqb2u5u3", "organization_id": "doe"},
@@ -617,7 +621,7 @@
         "redirect_uri": "",
         "logout_redirect_uri": "",
         "secret": "<SEEDER_M2M_SCHEDULER_APP_SECRET>",
-        "id": "f7p2k8w5jv4c1rm6xn3q9",
+        "id": "d5q7l2m9r3w1x6bp8cv0j",
         "is_third_party": false
       },
       {
@@ -642,16 +646,6 @@
         "apply_management_api_role": true
       },
       {
-        "name": "M2M Analytics API",
-        "description": "Machine 2 Machine application used to communicate with the Analytics APIs",
-        "type": "MachineToMachine",
-        "redirect_uri": "",
-        "logout_redirect_uri": "",
-        "secret": "<SEEDER_M2M_ANALYTICS_API_APP_SECRET>",
-        "id": "03emabp0dwznxw414mxme",
-        "is_third_party": false
-      },
-      {
         "name": "Journey Builder Building Block",
         "description": "Journey Builder App for Building Block",
         "type": "Traditional",
@@ -672,6 +666,16 @@
         "logout_redirect_uri": "",
         "secret": "<SEEDER_M2M_JOURNEY_APP_SECRET>",
         "id": "ca0c4izoo6dli4vko06g3"
+      },
+      {
+        "name": "M2M Analytics API",
+        "description": "Machine 2 Machine application used to communicate with the Analytics APIs",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_M2M_ANALYTICS_API_APP_SECRET>",
+        "id": "03emabp0dwznxw414mxme",
+        "is_third_party": false
       },
       {
         "name": "M2M Uploader",
@@ -710,12 +714,12 @@
         "redirect_uri": "<FEATURE_FLAGS_UNLEASH_APP_REDIRECT_URI>",
         "logout_redirect_uri": "<FEATURE_FLAGS_UNLEASH_APP_LOGOUT_REDIRECT_URI>",
         "secret": "<FEATURE_FLAGS_UNLEASH_APP_SECRET>",
-        "id": "43geanp0dwznxw412mxme",
+        "id": "13weafp5dcznqc436mxko",
         "is_third_party": false
       },
       {
         "name": "M2M Public Servant Journey Reader",
-        "description": "Machine 2 Machine application used to communicate between services and Journey resources for public servant",
+        "description": "Machine 2 Machine application used to communicate between services and Journey Builder resources for public servant",
         "type": "MachineToMachine",
         "redirect_uri": "",
         "logout_redirect_uri": "",
@@ -740,7 +744,7 @@
         "redirect_uri": "",
         "logout_redirect_uri": "",
         "secret": "<SEEDER_M2M_MESSAGING_APP_SECRET>",
-        "id": "k3wblfnr6h8b8x8l8nigt",
+        "id": "03jn5vm2pfh3a0433p4fp",
         "is_third_party": false
       },
       {
@@ -764,16 +768,6 @@
         "is_third_party": false
       },
       {
-        "name": "Digital Postbox M2M Proxy",
-        "description": "Machine 2 Machine application used by the digital postbox proxy",
-        "type": "MachineToMachine",
-        "redirect_uri": "",
-        "logout_redirect_uri": "",
-        "secret": "<SEEDER_DIGITAL_POSTBOX_M2M_APP_SECRET>",
-        "id": "r58qdwh2da6qtsqb2u5u3",
-        "is_third_party": false
-      },
-      {
         "name": "Digital Postbox M2M Profiles Exporter",
         "description": "Machine 2 Machine application used by the digital postbox profiles exporter",
         "type": "MachineToMachine",
@@ -781,6 +775,16 @@
         "logout_redirect_uri": "",
         "secret": "<SEEDER_DIGITAL_POSTBOX_M2M_PROFILE_EXPORTER_APP_SECRET>",
         "id": "v32qmzp9x7lh5f8kwe6ut",
+        "is_third_party": false
+      },
+      {
+        "name": "Digital Postbox M2M Proxy",
+        "description": "Machine 2 Machine application used by the digital postbox proxy",
+        "type": "MachineToMachine",
+        "redirect_uri": "",
+        "logout_redirect_uri": "",
+        "secret": "<SEEDER_DIGITAL_POSTBOX_M2M_APP_SECRET>",
+        "id": "r58qdwh2da6qtsqb2u5u3",
         "is_third_party": false
       }
     ],
@@ -816,11 +820,6 @@
         "indicator": "<SEEDER_ANALYTICS_API_INDICATOR>"
       },
       {
-        "id": "journey-api",
-        "name": "Journey Building Block API",
-        "indicator": "<SEEDER_JOURNEY_API_INDICATOR>"
-      },
-      {
         "id": "otel-collector-http",
         "name": "Observability Open Telemetry Collector HTTP",
         "indicator": "<SEEDER_OTEL_COLLECTOR_HTTP_INDICATOR>"
@@ -831,9 +830,14 @@
         "indicator": "<SEEDER_OTEL_COLLECTOR_GRPC_INDICATOR>"
       },
       {
+        "id": "journey-api",
+        "name": "Journey Building Block API",
+        "indicator": "<SEEDER_JOURNEY_API_INDICATOR>"
+      },
+      {
         "id": "o11y-dashboard",
         "name": "Observability Dashboard Application",
-        "indicator": "https://grafana.observability.dev.blocks.gov.ie/"
+        "indicator": "<SEEDER_O11Y_DASHBOARD_APP_INDICATOR>"
       },
       {
         "id": "formsie-sub-api",
@@ -1038,7 +1042,7 @@
           }
         ],
         "type": "MachineToMachine",
-        "related_application_ids": ["k3wblfnr6h8b8x8l8nigt"]
+        "related_application_ids": ["03jn5vm2pfh3a0433p4fp"]
       },
       {
         "id": "m2m-onboarding",


### PR DESCRIPTION
Added separated seeder for uat and prod

**Please note**: at the moment we are maintaining the `ogcio-seeder` without suffix file, we will remove that once we have updated all the manifests as expected