### PR TITLE
feat(core): AB#26048 - added organizations from Digital Postbox

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
@@ -27,24 +27,14 @@
         "id": "doe"
       },
       {
-        "name": "Health Service Executive",
-        "description": "Health Service Executive - Imported from Digital Postbox",
-        "id": "hse"
-      },
-      {
         "name": "Department of Social Protection",
         "description": "Department of Social Protection - Imported from Digital Postbox",
         "id": "dsp"
       },
       {
-        "name": "Limerick City and County Council",
-        "description": "Limerick City and County Council - Imported from Digital Postbox",
-        "id": "lcc"
-      },
-      {
-        "name": "Messaging Test",
-        "description": "Messaging Test - Imported from Digital Postbox",
-        "id": "msg-dp"
+        "name": "HAP Shared Services Centre",
+        "description": "HAP Shared Services Centre - Imported from Digital Postbox",
+        "id": "hap"
       }
     ],
     "organization_permissions": {

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder.json
@@ -27,24 +27,14 @@
         "id": "doe"
       },
       {
-        "name": "Health Service Executive",
-        "description": "Health Service Executive - Imported from Digital Postbox",
-        "id": "hse"
-      },
-      {
         "name": "Department of Social Protection",
         "description": "Department of Social Protection - Imported from Digital Postbox",
         "id": "dsp"
       },
       {
-        "name": "Limerick City and County Council",
-        "description": "Limerick City and County Council - Imported from Digital Postbox",
-        "id": "lcc"
-      },
-      {
-        "name": "Messaging Test",
-        "description": "Messaging Test - Imported from Digital Postbox",
-        "id": "msg-dp"
+        "name": "HAP Shared Services Centre",
+        "description": "HAP Shared Services Centre - Imported from Digital Postbox",
+        "id": "hap"
       }
     ],
     "organization_permissions": {


### PR DESCRIPTION
Set up organizations ased on the Organization.json file digital postbox have uploaded to Minio for prod

Please note: the seeder file without suffix will be removed as soon as we deploy latest version to prod that contains the `ogcio-seeder-prod` file, so we will use a specific seed file for each environment