### PR TITLE
Chore: AB#28747 assign role on login

### DIFF
--- a/packages/core/src/libraries/ogcio-user.ts
+++ b/packages/core/src/libraries/ogcio-user.ts
@@ -144,7 +144,10 @@ export const manageDefaultUserRole = async (
     );
     return assignInactivePublicServantRole(user, organizationQueries, ctx);
   }
-  if (identities.includes(OGCIO_MY_GOV_ID_IDENTITY)) {
+  const relatedOrganizations = await organizationQueries.relations.users.getOrganizationsByUserId(
+    user.id
+  );
+  if (identities.includes(OGCIO_MY_GOV_ID_IDENTITY) && relatedOrganizations.length === 0) {
     getConsoleLogFromContext(ctx).info(
       `OGCIO: User registration - MyGovID identity found, assigning citizen role to the user.`
     );

--- a/packages/core/src/libraries/ogcio-user.ts
+++ b/packages/core/src/libraries/ogcio-user.ts
@@ -121,7 +121,8 @@ export const manageDefaultUserRole = async (
     usersRoles: CreateUsersRole[]
   ) => Promise<QueryResult<QueryResultRow> | undefined>,
   organizationQueries: OrganizationQueries,
-  ctx: WithHooksAndLogsContext
+  ctx: WithHooksAndLogsContext,
+  registrationStep = true
 ) => {
   getConsoleLogFromContext(ctx).info(
     `OGCIO: New user registration with tenantID: ${user.tenantId}`
@@ -137,7 +138,7 @@ export const manageDefaultUserRole = async (
     `OGCIO: User registration - user identities: ${identities.join(', ')}`
   );
 
-  if (identities.includes(OGCIO_ENTRA_ID_IDENTITY)) {
+  if (identities.includes(OGCIO_ENTRA_ID_IDENTITY) && registrationStep) {
     getConsoleLogFromContext(ctx).info(
       `OGCIO: User registration - EntraID identity found, assigning inactive public servant role to the user.`
     );

--- a/packages/core/src/routes/experience/classes/experience-interaction.ts
+++ b/packages/core/src/routes/experience/classes/experience-interaction.ts
@@ -9,6 +9,7 @@ import { type LogEntry } from '#src/middleware/koa-audit-log.js';
 import type TenantContext from '#src/tenants/TenantContext.js';
 import assertThat from '#src/utils/assert-that.js';
 
+import { manageDefaultUserRole } from '../../../libraries/ogcio-user.js';
 import {
   interactionProfileGuard,
   type Interaction,
@@ -470,6 +471,19 @@ export default class ExperienceInteraction {
     this.ctx.body = { redirectTo };
 
     this.ctx.assignInteractionHookResult({ userId: user.id });
+
+    // OGCIO
+    const registrationStep = false;
+    const { organizations, roles, usersRoles } = this.tenant.queries;
+    await manageDefaultUserRole(
+      user,
+      roles.findRoleById,
+      usersRoles.insertUsersRoles,
+      organizations,
+      this.ctx,
+      registrationStep
+    );
+    // END OGCIO
 
     if (Object.keys(this.profile.data).length > 0 || mfaVerifications.length > 0) {
       this.ctx.appendDataHookContext('User.Data.Updated', { user: updatedUser });


### PR DESCRIPTION
### Description
Added the check for the default roles on login
**This check is needed because all the citizens we are creating through profile-import don't have an assigned role on login**
It must add roles only for citizen if they don't have the citizen role yet, not to public servants

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**
