### PR TITLE
feat: add keyvault permissions to LogTo seeder configuration AB#28760

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -998,6 +998,13 @@
               "journey:run.self:read",
               "journey:run.self:write"
             ]
+          },
+          {
+            "resource_id": "formsie-sub-api",
+            "specific_permissions": [
+              "keyvault:secret.self:read",
+              "keyvault:secret.self:write"
+            ]
           }
         ]
       },

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -98,8 +98,8 @@
         "dashboard:admin:read",
         "dashboard:admin:write",
         "formsie:submission:read",
-        "keyvault:encrypt",
-        "keyvault:decrypt",
+        "keyvault:secret:write",
+        "keyvault:secret:read",
         "profile:user.admin:write",
         "profile:user.admin:read"
       ]
@@ -488,8 +488,8 @@
         "description": "Role for Applications that need access to the FormsIE service",
         "specific_permissions": [
           "formsie:submission:read",
-          "keyvault:encrypt",
-          "keyvault:decrypt"
+          "keyvault:secret:write",
+          "keyvault:secret:read"
         ]
       },
       {
@@ -949,8 +949,8 @@
         "resource_id": "formsie-sub-api",
         "specific_permissions": [
           "formsie:submission:read",
-          "keyvault:encrypt",
-          "keyvault:decrypt"
+          "keyvault:secret:write",
+          "keyvault:secret:read"
         ]
       }
     ],
@@ -1010,8 +1010,8 @@
             "resource_id": "formsie-sub-api",
             "specific_permissions": [
               "formsie:submission:read",
-              "keyvault:encrypt",
-              "keyvault:decrypt"
+              "keyvault:secret:write",
+              "keyvault:secret:read"
             ]
           }          
         ]

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -98,6 +98,8 @@
         "dashboard:admin:read",
         "dashboard:admin:write",
         "formsie:submission:read",
+        "keyvault:encrypt",
+        "keyvault:decrypt",
         "profile:user.admin:write",
         "profile:user.admin:read"
       ]
@@ -485,7 +487,9 @@
         "name": "FormsIE Admin Role",
         "description": "Role for Applications that need access to the FormsIE service",
         "specific_permissions": [
-          "formsie:submission:read"
+          "formsie:submission:read",
+          "keyvault:encrypt",
+          "keyvault:decrypt"
         ]
       },
       {
@@ -944,7 +948,9 @@
       {
         "resource_id": "formsie-sub-api",
         "specific_permissions": [
-          "formsie:submission:read"
+          "formsie:submission:read",
+          "keyvault:encrypt",
+          "keyvault:decrypt"
         ]
       }
     ],
@@ -1002,7 +1008,11 @@
         "permissions": [
           {
             "resource_id": "formsie-sub-api",
-            "specific_permissions": ["formsie:submission:read"]
+            "specific_permissions": [
+              "formsie:submission:read",
+              "keyvault:encrypt",
+              "keyvault:decrypt"
+            ]
           }          
         ]
       },


### PR DESCRIPTION
## Summary

Add keyvault permissions to LogTo seeder configuration to support local Vault development setup.

This PR adds the necessary keyvault secret management permissions to the LogTo seeder configuration, enabling proper integration with the KeyVault service for local development.

## Azure Board Work Item

- **Work Item**: [AB#28760](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/28760) - Local Vault
- **URL**: https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/28760

### Work Item Details

**Title**: Local Vault  
**Type**: User Story  
**State**: In Progress  
**Assigned To**: Florian Traverse  
**Description**: As a developer, when I need to develop the Keyvault, then I need to be able to run Vault from docker-compose as a dependency

## Changes

- ✅ Added `keyvault:secret:read` and `keyvault:secret:write` permissions to organization_permissions.specific_permissions
- ✅ Added `keyvault:secret.self:read` and `keyvault:secret.self:write` permissions for self-service access
- ✅ Added keyvault permissions to FormsIE Admin Role
- ✅ Added keyvault permissions to formsie-sub-api resource
- ✅ Updated application permissions for FormsIE service

## Related PRs

This PR is related to the formsSG-4IE repository changes for [AB#28760](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/28760):
- formsSG-4IE PR: [#1767](https://github.com/ogcio/formsSG-4IE/pull/1767) - feat: implement local vault development setup with APIcast integration

## Testing

- [ ] Unit tests pass
- [ ] Integration tests pass  
- [ ] Manual testing with local Vault setup
- [ ] Verify keyvault permissions work correctly

---

*This PR addresses Azure Board work item [AB#28760](https://dev.azure.com/OGCIO-Digital-Services/2aff229e-6625-4ad7-8f51-ff850dd878ec/_workitems/edit/28760) and enables local Vault development setup in LogTo.*