### PR TITLE
Fix: citizen role assignment uat

### DIFF
--- a/packages/core/src/routes/interaction/actions/submit-interaction.ts
+++ b/packages/core/src/routes/interaction/actions/submit-interaction.ts
@@ -275,6 +275,19 @@ async function handleSubmitSignIn(
   appInsights.client?.trackEvent({
     name: getEventName(Component.Core, CoreEvent.SignIn),
   });
+
+  // OGCIO
+  const registrationStep = false;
+  const { organizations, roles, usersRoles } = queries;
+  await manageDefaultUserRole(
+    user,
+    roles.findRoleById,
+    usersRoles.insertUsersRoles,
+    organizations,
+    ctx,
+    registrationStep
+  );
+  // END OGCIO
 }
 
 export default async function submitInteraction(


### PR DESCRIPTION
Given that in UAT is using another API to manage sign-in, added management of default role in interaction API