### PR TITLE
fix: rename abp to acp

### DIFF
--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-local.json
@@ -7,8 +7,8 @@
         "id": "ogcio"
       },
       {
-        "name": "An Bord Pleanála",
-        "description": "An Bord Pleanála",
+        "name": "An Coimisiún Pleanála",
+        "description": "An Coimisiún Pleanála",
         "id": "abp"
       },
       {

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-prod.json
@@ -12,8 +12,8 @@
         "id": "nearform-testing"
       },
       {
-        "name": "An Bord Pleanála",
-        "description": "An Bord Pleanála",
+        "name": "An Coimisiún Pleanála",
+        "description": "An Coimisiún Pleanála",
         "id": "abp"
       },
       {

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-testing.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-testing.json
@@ -7,8 +7,8 @@
         "id": "ogcio"
       },
       {
-        "name": "An Bord Pleanála",
-        "description": "An Bord Pleanála",
+        "name": "An Coimisiún Pleanála",
+        "description": "An Coimisiún Pleanála",
         "id": "abp"
       },
       {

--- a/packages/cli/src/commands/database/ogcio/ogcio-seeder-uat.json
+++ b/packages/cli/src/commands/database/ogcio/ogcio-seeder-uat.json
@@ -12,8 +12,8 @@
         "id": "nearform-testing"
       },
       {
-        "name": "An Bord Pleanála",
-        "description": "An Bord Pleanála",
+        "name": "An Coimisiún Pleanála",
+        "description": "An Coimisiún Pleanála",
         "id": "abp"
       },
       {


### PR DESCRIPTION
[comment]: <> (This file has been added on OGCIO fork)
### Ticket:

- [29729](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_boards/board/t/Gold/Stories?workitem=29729)

### Description

Renaming ABP to ACP. We're not changing the ID, as changing the ID will create a new organization, not change the ID of the current one. The ID will still be "abp", but as this is an internal id and is never showed to the customer, it shouldn't be a problem. 

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [X] **Dev change**

